### PR TITLE
Default download of text encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ make mps       # Apple Silicon (fastest)
 # or: make blas    # Intel Mac / Linux with OpenBLAS
 # or: make generic # Pure C, no dependencies
 
-# Download the model (~16GB)
+# Download the model (~16GB with text encoder)
 pip install huggingface_hub
-python download_model.py
+python download_model.py --include-text-encoder
 
 # Generate an image
 ./flux -d flux-klein-model -p "A woman wearing sunglasses" -o output.png
@@ -152,10 +152,10 @@ The model weights are downloaded from HuggingFace:
 
 ```bash
 pip install huggingface_hub
-python download_model.py
+python download_model.py --include-text-encoder
 ```
 
-This downloads approximately 16GB to `./flux-klein-model`:
+This downloads approximately 16GB to `./flux-klein-model` (use `--include-text-encoder` to get the text encoder):
 - VAE (~300MB)
 - Transformer (~4GB)
 - Qwen3-4B Text Encoder (~8GB)

--- a/download_model.py
+++ b/download_model.py
@@ -3,7 +3,7 @@
 Download FLUX.2-klein-4B model files from HuggingFace.
 
 Usage:
-    python download_model.py [--output-dir DIR]
+    python download_model.py [--output-dir DIR] [--include-text-encoder]
 
 Requirements:
     pip install huggingface_hub


### PR DESCRIPTION
Thanks for putting this together!

I followed the instructions and saw this:
```log
Reloading encoder...qwen3_tokenizer_load: cannot open flux-klein-model/tokenizer/tokenizer.json
qwen3_encoder_load: failed to load tokenizer
done (0.0s)
Warning: Failed to reload text encoder
```

<img width="240" height="240" alt="output" src="https://github.com/user-attachments/assets/87de8bab-a9c4-4850-afa2-a4d4f4ee1a87" />

Then I tried:
```sh
python download_model.py --include-text-encoder
```

and it fixed the warnings, so I updated the documentation, and got it working:

<img width="240" height="240" alt="woman" src="https://github.com/user-attachments/assets/ca0244fc-9bac-46fd-abdd-72dd227fb969" />