### PR TITLE
Make download script executable with uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ misc/
 *.a
 *.so
 *.dylib
+__pycache__/


### PR DESCRIPTION
This pull request updates the `download_model.py` script to make it more user-friendly, portable, and robust. The script now uses inline dependency management with `uv`, adds more flexible CLI options, and provides improved authentication instructions and error handling.

**Improvements to script portability and dependency management:**
* Added PEP 723 metadata and switched the shebang to use `uv run --script`, making the script self-contained and automatically managing dependencies.

**Enhancements to CLI options and flexibility:**
* Added new command-line arguments: `--repo-id` (to specify the Hugging Face repo), and `--revision` (to select a specific git revision/branch/tag), in addition to the existing `--output-dir`.
* Updated usage instructions and output to reflect the new options and default values. 

**Robustness and user experience improvements:**
* Switched to using the Hugging Face Python API exclusively, removed the import error check, and improved error messages.
* Improved authentication instructions to guide users to set `HF_TOKEN` or `HUGGINGFACE_HUB_TOKEN` environment variables instead of using the CLI login.
* Enabled resumable downloads and clarified which files are included/excluded.