### PR TITLE
fix(metal): prevent nil crash in shader path lookup

### DIFF
--- a/flux_metal.m
+++ b/flux_metal.m
@@ -2952,11 +2952,16 @@ int flux_metal_init_shaders(void) {
 
         /* Try to find the shader file in various locations */
         NSString *shaderPath = nil;
-        NSArray *searchPaths = @[
+        NSMutableArray *searchPaths = [NSMutableArray arrayWithObjects:
             @"flux_shaders.metal",
             @"./flux_shaders.metal",
-            [[NSBundle mainBundle] pathForResource:@"flux_shaders" ofType:@"metal"],
-        ];
+            @"flux2.c/flux_shaders.metal",
+            @"./flux2.c/flux_shaders.metal",
+            nil];
+        NSString *bundlePath = [[NSBundle mainBundle] pathForResource:@"flux_shaders" ofType:@"metal"];
+        if (bundlePath) {
+            [searchPaths addObject:bundlePath];
+        }
 
         for (NSString *path in searchPaths) {
             if (path && [[NSFileManager defaultManager] fileExistsAtPath:path]) {


### PR DESCRIPTION
Problem: 
`flux_metal_init_shaders()` crashes with `NSInvalidArgumentException` when `pathForResource:ofType:` returns `nil`. The `@[]` array literal cannot contain `nil` values, causing a crash when the binary is run from a different directory or packaged in an app bundle.

Solution: 
Use `NSMutableArray` and conditionally add the bundle path only when non-nil. Also add flux2.c/ relative paths for additional robustness.

Notes: 
Tested on macOS 14.4.1 (arm64). Reproduced by copying binary to /tmp and running --help.

Closes #17 