### PR TITLE
feat: ROCm Backend Full GPU-Resident Architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,18 +50,18 @@ endif
 	@echo ""
 	@echo "Example: make mps && ./flux -d flux-klein-model -p \"a cat\" -o cat.png"
 
-# =============================================================================
+# ======================================================================
 # Backend: generic (pure C, no BLAS)
-# =============================================================================
+# ======================================================================
 generic: CFLAGS = $(CFLAGS_BASE) -DGENERIC_BUILD
 generic: clean $(TARGET)
 	@echo ""
 	@echo "Built with GENERIC backend (pure C, no BLAS)"
 	@echo "This will be slow but has zero dependencies."
 
-# =============================================================================
+# ======================================================================
 # Backend: blas (Accelerate on macOS, OpenBLAS on Linux)
-# =============================================================================
+# ======================================================================
 ifeq ($(UNAME_S),Darwin)
 blas: CFLAGS = $(CFLAGS_BASE) -DUSE_BLAS -DACCELERATE_NEW_LAPACK
 blas: LDFLAGS += -framework Accelerate
@@ -73,9 +73,9 @@ blas: clean $(TARGET)
 	@echo ""
 	@echo "Built with BLAS backend (~30x faster than generic)"
 
-# =============================================================================
+# ======================================================================
 # Backend: mps (Apple Silicon Metal GPU)
-# =============================================================================
+# ======================================================================
 ifeq ($(UNAME_S),Darwin)
 ifeq ($(UNAME_M),arm64)
 MPS_CFLAGS = $(CFLAGS_BASE) -DUSE_BLAS -DUSE_METAL -DACCELERATE_NEW_LAPACK
@@ -110,9 +110,9 @@ mps:
 	@exit 1
 endif
 
-# =============================================================================
+# ======================================================================
 # Backend: rocm (AMD GPUs with ROCm/HIP)
-# =============================================================================
+# ======================================================================
 ifeq ($(shell command -v hipcc 2> /dev/null),)
 rocm:
 	@echo "Error: ROCm/hipcc not found. Install ROCm toolkit first."
@@ -152,9 +152,9 @@ rocm/flux_rocm_kernels.o: rocm/flux_rocm_kernels.hip rocm/flux_rocm.h
 
 endif
 
-# =============================================================================
+# ======================================================================
 # Build rules
-# =============================================================================
+# ======================================================================
 $(TARGET): $(OBJS) $(CLI_OBJS) main.o
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
@@ -171,9 +171,9 @@ debug: CFLAGS = $(DEBUG_CFLAGS)
 debug: LDFLAGS += -fsanitize=address
 debug: clean $(TARGET)
 
-# =============================================================================
+# ======================================================================
 # Test and utilities
-# =============================================================================
+# ======================================================================
 test:
 	@python3 run_test.py --flux-binary ./$(TARGET)
 
@@ -200,6 +200,7 @@ install: $(TARGET) $(LIB)
 clean:
 	rm -f $(OBJS) $(CLI_OBJS) *.mps.o flux_metal.o main.o $(TARGET) $(LIB)
 	rm -f flux_shaders_source.h
+	rm -f *.rocm.o rocm/*.o rocm/*.a
 
 info:
 	@echo "Platform: $(UNAME_S) $(UNAME_M)"
@@ -216,9 +217,9 @@ else
 	@echo "  blas    - OpenBLAS (requires libopenblas-dev)"
 endif
 
-# =============================================================================
+# ======================================================================
 # Dependencies
-# =============================================================================
+# ======================================================================
 flux.o: flux.c flux.h flux_kernels.h flux_safetensors.h flux_qwen3.h
 flux_kernels.o: flux_kernels.c flux_kernels.h
 flux_tokenizer.o: flux_tokenizer.c flux.h

--- a/flux_transformer.c
+++ b/flux_transformer.c
@@ -50,6 +50,11 @@ static double tf_get_time_ms(void) {
 #include "flux_metal.h"
 #endif
 
+/* Use ROCm for GPU acceleration on AMD GPUs */
+#ifdef USE_ROCM
+#include "rocm/flux_rocm.h"
+#endif
+
 /* Enable BF16 pipeline debug logging when FLUX_BF16_DEBUG is set. */
 #ifdef USE_METAL
 static int bf16_debug_enabled(void) {
@@ -2622,6 +2627,506 @@ cleanup:
 }
 #endif /* USE_METAL */
 
+#ifdef USE_ROCM
+/* ROCm single block forward - keeps data on GPU throughout the block.
+ * Returns 1 if GPU path was used, 0 to fall back to CPU path.
+ */
+static int single_block_forward_rocm(float *hidden, const single_block_t *block,
+                                     const float *t_emb, const float *adaln_weight,
+                                     const float *img_rope_cos, const float *img_rope_sin,
+                                     const float *txt_rope_cos, const float *txt_rope_sin,
+                                     int seq, int img_offset, flux_transformer_t *tf) {
+    /* GPU path enabled - RoPE bug fixed (was using axis_dim instead of head_dim) */
+    
+    if (!flux_rocm_available()) return 0;
+    
+    /* Need f32 weights for ROCm path (bf16 not implemented yet) */
+    if (block->qkv_mlp_weight == NULL || block->proj_mlp_weight == NULL) return 0;
+    
+    int h_size = tf->hidden_size;
+    int heads = tf->num_heads;
+    int head_dim = tf->head_dim;
+    int mlp_hidden = tf->mlp_hidden;
+    int fused_dim = h_size * 3 + mlp_hidden * 2;
+    float eps = 1e-6f;
+    int axis_dim = 32;
+    
+    /* === Phase 1: Compute AdaLN modulation on CPU (small, not worth GPU) === */
+    int mod_size = h_size * 3;
+    float *t_emb_silu = tf->t_emb_silu;
+    for (int i = 0; i < h_size; i++) {
+        float x = t_emb[i];
+        t_emb_silu[i] = x / (1.0f + expf(-x));
+    }
+    float *mod_params = tf->work2 + seq * fused_dim;
+    flux_linear_nobias(mod_params, t_emb_silu, adaln_weight, 1, h_size, mod_size);
+    
+    float *shift = mod_params;
+    float *scale = mod_params + h_size;
+    float *gate = mod_params + h_size * 2;
+    
+    /* === Phase 2: Create GPU tensors === */
+    flux_rocm_batch_begin();
+    
+    flux_rocm_tensor_t hidden_gpu = flux_rocm_tensor_create(hidden, seq * h_size);
+    if (!hidden_gpu) {
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* Allocate intermediate tensors */
+    flux_rocm_tensor_t norm_gpu = flux_rocm_tensor_alloc(seq * h_size);
+    flux_rocm_tensor_t q_gpu = flux_rocm_tensor_alloc(seq * h_size);
+    flux_rocm_tensor_t k_gpu = flux_rocm_tensor_alloc(seq * h_size);
+    flux_rocm_tensor_t v_gpu = flux_rocm_tensor_alloc(seq * h_size);
+    flux_rocm_tensor_t gate_mlp = flux_rocm_tensor_alloc(seq * mlp_hidden);
+    flux_rocm_tensor_t up_gpu = flux_rocm_tensor_alloc(seq * mlp_hidden);
+    flux_rocm_tensor_t attn_out_gpu = flux_rocm_tensor_alloc(seq * h_size);
+    flux_rocm_tensor_t concat_gpu = flux_rocm_tensor_alloc(seq * (h_size + mlp_hidden));
+    
+    if (!norm_gpu || !q_gpu || !k_gpu || !v_gpu || !gate_mlp || !up_gpu || 
+        !attn_out_gpu || !concat_gpu) {
+        if (hidden_gpu) flux_rocm_tensor_free(hidden_gpu);
+        if (norm_gpu) flux_rocm_tensor_free(norm_gpu);
+        if (q_gpu) flux_rocm_tensor_free(q_gpu);
+        if (k_gpu) flux_rocm_tensor_free(k_gpu);
+        if (v_gpu) flux_rocm_tensor_free(v_gpu);
+        if (gate_mlp) flux_rocm_tensor_free(gate_mlp);
+        if (up_gpu) flux_rocm_tensor_free(up_gpu);
+        if (attn_out_gpu) flux_rocm_tensor_free(attn_out_gpu);
+        if (concat_gpu) flux_rocm_tensor_free(concat_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* === Phase 3: AdaLN normalization on GPU === */
+    flux_rocm_gpu_adaln_norm(norm_gpu, hidden_gpu, shift, scale, seq, h_size, eps);
+    
+    /* === Phase 4: Fused QKV + MLP projection on GPU === */
+    flux_rocm_tensor_t fused_gpu = flux_rocm_gpu_linear(norm_gpu, block->qkv_mlp_weight,
+                                                        seq, h_size, fused_dim);
+    if (!fused_gpu) {
+        flux_rocm_tensor_free(hidden_gpu);
+        flux_rocm_tensor_free(norm_gpu);
+        flux_rocm_tensor_free(q_gpu);
+        flux_rocm_tensor_free(k_gpu);
+        flux_rocm_tensor_free(v_gpu);
+        flux_rocm_tensor_free(gate_mlp);
+        flux_rocm_tensor_free(up_gpu);
+        flux_rocm_tensor_free(attn_out_gpu);
+        flux_rocm_tensor_free(concat_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* === Phase 5: Split fused output on GPU === */
+    flux_rocm_gpu_split_qkv_mlp(fused_gpu, q_gpu, k_gpu, v_gpu, gate_mlp, up_gpu,
+                                seq, h_size, mlp_hidden);
+    
+    /* === Phase 6: QK RMSNorm on GPU === */
+    flux_rocm_gpu_qk_rms_norm(q_gpu, k_gpu, block->norm_q_weight, block->norm_k_weight,
+                              seq, heads, head_dim, eps);
+    
+    /* === Phase 7: Apply unified RoPE on GPU === */
+    flux_rocm_gpu_rope_unified(q_gpu, k_gpu,
+                               txt_rope_cos, txt_rope_sin,
+                               img_rope_cos, img_rope_sin,
+                               seq, img_offset, heads, head_dim, axis_dim);
+    
+    /* === Phase 8: Self-attention on GPU === */
+    float attn_scale = 1.0f / sqrtf((float)head_dim);
+    if (!flux_rocm_gpu_attention_fused(attn_out_gpu, q_gpu, k_gpu, v_gpu,
+                                       seq, seq, heads, head_dim, attn_scale)) {
+        flux_rocm_tensor_free(hidden_gpu);
+        flux_rocm_tensor_free(norm_gpu);
+        flux_rocm_tensor_free(fused_gpu);
+        flux_rocm_tensor_free(q_gpu);
+        flux_rocm_tensor_free(k_gpu);
+        flux_rocm_tensor_free(v_gpu);
+        flux_rocm_tensor_free(gate_mlp);
+        flux_rocm_tensor_free(up_gpu);
+        flux_rocm_tensor_free(attn_out_gpu);
+        flux_rocm_tensor_free(concat_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* === Phase 9: SwiGLU on GPU === */
+    flux_rocm_gpu_silu_mul(gate_mlp, up_gpu, seq * mlp_hidden);
+    
+    /* === Phase 10: Concat attention + MLP outputs on GPU === */
+    flux_rocm_gpu_concat_attn_mlp(attn_out_gpu, gate_mlp, concat_gpu, seq, h_size, mlp_hidden);
+    
+    /* === Phase 11: Final projection on GPU === */
+    flux_rocm_tensor_t proj_out_gpu = flux_rocm_gpu_linear(concat_gpu, block->proj_mlp_weight,
+                                                           seq, h_size + mlp_hidden, h_size);
+    if (!proj_out_gpu) {
+        flux_rocm_tensor_free(hidden_gpu);
+        flux_rocm_tensor_free(norm_gpu);
+        flux_rocm_tensor_free(fused_gpu);
+        flux_rocm_tensor_free(q_gpu);
+        flux_rocm_tensor_free(k_gpu);
+        flux_rocm_tensor_free(v_gpu);
+        flux_rocm_tensor_free(gate_mlp);
+        flux_rocm_tensor_free(up_gpu);
+        flux_rocm_tensor_free(attn_out_gpu);
+        flux_rocm_tensor_free(concat_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* === Phase 12: Gated add residual on GPU === */
+    flux_rocm_gpu_gated_add(hidden_gpu, gate, proj_out_gpu, seq, h_size);
+    
+    /* === Phase 13: Sync and copy result back === */
+    flux_rocm_batch_end();
+    flux_rocm_tensor_read(hidden_gpu, hidden, seq * h_size);
+    
+    /* === Cleanup === */
+    flux_rocm_tensor_free(hidden_gpu);
+    flux_rocm_tensor_free(norm_gpu);
+    flux_rocm_tensor_free(fused_gpu);
+    flux_rocm_tensor_free(q_gpu);
+    flux_rocm_tensor_free(k_gpu);
+    flux_rocm_tensor_free(v_gpu);
+    flux_rocm_tensor_free(gate_mlp);
+    flux_rocm_tensor_free(up_gpu);
+    flux_rocm_tensor_free(attn_out_gpu);
+    flux_rocm_tensor_free(concat_gpu);
+    flux_rocm_tensor_free(proj_out_gpu);
+    
+    return 1;  /* GPU path succeeded */
+}
+
+/* ROCm double block forward - keeps data on GPU throughout the block.
+ * Returns 1 if GPU path was used, 0 to fall back to CPU path.
+ */
+static int double_block_forward_rocm(float *img_hidden, float *txt_hidden,
+                                     const double_block_t *block,
+                                     const float *img_mod, const float *txt_mod,
+                                     const float *img_rope_cos, const float *img_rope_sin,
+                                     const float *txt_rope_cos, const float *txt_rope_sin,
+                                     int img_seq, int txt_seq,
+                                     flux_transformer_t *tf) {
+    if (!flux_rocm_available()) return 0;
+    
+    /* Need f32 weights for ROCm path (bf16 not implemented yet) */
+    if (block->img_q_weight == NULL || block->txt_q_weight == NULL) return 0;
+    
+    int hidden = tf->hidden_size;
+    int heads = tf->num_heads;
+    int head_dim = tf->head_dim;
+    int mlp_hidden = tf->mlp_hidden;
+    int total_seq = img_seq + txt_seq;
+    float eps = 1e-6f;
+    
+    /* Extract pre-computed modulation parameters (computed on CPU, small) */
+    const float *img_shift1 = img_mod;
+    const float *img_scale1 = img_mod + hidden;
+    const float *img_gate1 = img_mod + hidden * 2;
+    const float *img_shift2 = img_mod + hidden * 3;
+    const float *img_scale2 = img_mod + hidden * 4;
+    const float *img_gate2 = img_mod + hidden * 5;
+    
+    const float *txt_shift1 = txt_mod;
+    const float *txt_scale1 = txt_mod + hidden;
+    const float *txt_gate1 = txt_mod + hidden * 2;
+    const float *txt_shift2 = txt_mod + hidden * 3;
+    const float *txt_scale2 = txt_mod + hidden * 4;
+    const float *txt_gate2 = txt_mod + hidden * 5;
+    
+    /* === Create GPU tensors === */
+    flux_rocm_batch_begin();
+    
+    flux_rocm_tensor_t img_hidden_gpu = flux_rocm_tensor_create(img_hidden, img_seq * hidden);
+    flux_rocm_tensor_t txt_hidden_gpu = flux_rocm_tensor_create(txt_hidden, txt_seq * hidden);
+    
+    if (!img_hidden_gpu || !txt_hidden_gpu) {
+        if (img_hidden_gpu) flux_rocm_tensor_free(img_hidden_gpu);
+        if (txt_hidden_gpu) flux_rocm_tensor_free(txt_hidden_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* Allocate intermediate tensors */
+    flux_rocm_tensor_t img_norm_gpu = flux_rocm_tensor_alloc(img_seq * hidden);
+    flux_rocm_tensor_t txt_norm_gpu = flux_rocm_tensor_alloc(txt_seq * hidden);
+    flux_rocm_tensor_t cat_k_gpu = flux_rocm_tensor_alloc(total_seq * hidden);
+    flux_rocm_tensor_t cat_v_gpu = flux_rocm_tensor_alloc(total_seq * hidden);
+    flux_rocm_tensor_t img_attn_out_gpu = flux_rocm_tensor_alloc(img_seq * hidden);
+    flux_rocm_tensor_t txt_attn_out_gpu = flux_rocm_tensor_alloc(txt_seq * hidden);
+    
+    if (!img_norm_gpu || !txt_norm_gpu || !cat_k_gpu || !cat_v_gpu ||
+        !img_attn_out_gpu || !txt_attn_out_gpu) {
+        /* Cleanup on failure */
+        if (img_hidden_gpu) flux_rocm_tensor_free(img_hidden_gpu);
+        if (txt_hidden_gpu) flux_rocm_tensor_free(txt_hidden_gpu);
+        if (img_norm_gpu) flux_rocm_tensor_free(img_norm_gpu);
+        if (txt_norm_gpu) flux_rocm_tensor_free(txt_norm_gpu);
+        if (cat_k_gpu) flux_rocm_tensor_free(cat_k_gpu);
+        if (cat_v_gpu) flux_rocm_tensor_free(cat_v_gpu);
+        if (img_attn_out_gpu) flux_rocm_tensor_free(img_attn_out_gpu);
+        if (txt_attn_out_gpu) flux_rocm_tensor_free(txt_attn_out_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* === Image stream: AdaLN -> QKV -> QK-norm -> RoPE === */
+    flux_rocm_gpu_adaln_norm(img_norm_gpu, img_hidden_gpu, img_shift1, img_scale1,
+                             img_seq, hidden, eps);
+    
+    /* Separate Q, K, V projections for image */
+    flux_rocm_tensor_t img_q_proj = flux_rocm_gpu_linear(img_norm_gpu, block->img_q_weight,
+                                                         img_seq, hidden, hidden);
+    flux_rocm_tensor_t img_k_proj = flux_rocm_gpu_linear(img_norm_gpu, block->img_k_weight,
+                                                         img_seq, hidden, hidden);
+    flux_rocm_tensor_t img_v_proj = flux_rocm_gpu_linear(img_norm_gpu, block->img_v_weight,
+                                                         img_seq, hidden, hidden);
+    
+    if (!img_q_proj || !img_k_proj || !img_v_proj) {
+        /* Cleanup and fallback */
+        flux_rocm_tensor_free(img_hidden_gpu);
+        flux_rocm_tensor_free(txt_hidden_gpu);
+        flux_rocm_tensor_free(img_norm_gpu);
+        flux_rocm_tensor_free(txt_norm_gpu);
+        if (img_q_proj) flux_rocm_tensor_free(img_q_proj);
+        if (img_k_proj) flux_rocm_tensor_free(img_k_proj);
+        if (img_v_proj) flux_rocm_tensor_free(img_v_proj);
+        flux_rocm_tensor_free(cat_k_gpu);
+        flux_rocm_tensor_free(cat_v_gpu);
+        flux_rocm_tensor_free(img_attn_out_gpu);
+        flux_rocm_tensor_free(txt_attn_out_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* QK normalization for image */
+    flux_rocm_gpu_qk_rms_norm(img_q_proj, img_k_proj,
+                              block->img_norm_q_weight, block->img_norm_k_weight,
+                              img_seq, heads, head_dim, eps);
+    
+    /* RoPE for image (2D positional encoding) */
+    flux_rocm_gpu_rope_2d(img_q_proj, img_rope_cos, img_rope_sin, img_seq, heads, head_dim);
+    flux_rocm_gpu_rope_2d(img_k_proj, img_rope_cos, img_rope_sin, img_seq, heads, head_dim);
+    
+    /* === Text stream: AdaLN -> QKV -> QK-norm -> RoPE === */
+    flux_rocm_gpu_adaln_norm(txt_norm_gpu, txt_hidden_gpu, txt_shift1, txt_scale1,
+                             txt_seq, hidden, eps);
+    
+    /* Separate Q, K, V projections for text */
+    flux_rocm_tensor_t txt_q_proj = flux_rocm_gpu_linear(txt_norm_gpu, block->txt_q_weight,
+                                                         txt_seq, hidden, hidden);
+    flux_rocm_tensor_t txt_k_proj = flux_rocm_gpu_linear(txt_norm_gpu, block->txt_k_weight,
+                                                         txt_seq, hidden, hidden);
+    flux_rocm_tensor_t txt_v_proj = flux_rocm_gpu_linear(txt_norm_gpu, block->txt_v_weight,
+                                                         txt_seq, hidden, hidden);
+    
+    if (!txt_q_proj || !txt_k_proj || !txt_v_proj) {
+        /* Cleanup - this is getting tedious, but safety first */
+        flux_rocm_tensor_free(img_hidden_gpu);
+        flux_rocm_tensor_free(txt_hidden_gpu);
+        flux_rocm_tensor_free(img_norm_gpu);
+        flux_rocm_tensor_free(txt_norm_gpu);
+        flux_rocm_tensor_free(img_q_proj);
+        flux_rocm_tensor_free(img_k_proj);
+        flux_rocm_tensor_free(img_v_proj);
+        if (txt_q_proj) flux_rocm_tensor_free(txt_q_proj);
+        if (txt_k_proj) flux_rocm_tensor_free(txt_k_proj);
+        if (txt_v_proj) flux_rocm_tensor_free(txt_v_proj);
+        flux_rocm_tensor_free(cat_k_gpu);
+        flux_rocm_tensor_free(cat_v_gpu);
+        flux_rocm_tensor_free(img_attn_out_gpu);
+        flux_rocm_tensor_free(txt_attn_out_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* QK normalization for text */
+    flux_rocm_gpu_qk_rms_norm(txt_q_proj, txt_k_proj,
+                              block->txt_norm_q_weight, block->txt_norm_k_weight,
+                              txt_seq, heads, head_dim, eps);
+    
+    /* RoPE for text (1D, axis 3 only) */
+    flux_rocm_gpu_rope_2d(txt_q_proj, txt_rope_cos, txt_rope_sin, txt_seq, heads, head_dim);
+    flux_rocm_gpu_rope_2d(txt_k_proj, txt_rope_cos, txt_rope_sin, txt_seq, heads, head_dim);
+    
+    /* === Joint attention: concatenate K,V then attend === */
+    /* Order: [txt, img] to match Python Flux2 */
+    flux_rocm_gpu_concat_tensors(txt_k_proj, img_k_proj, cat_k_gpu, txt_seq, img_seq, hidden);
+    flux_rocm_gpu_concat_tensors(txt_v_proj, img_v_proj, cat_v_gpu, txt_seq, img_seq, hidden);
+    
+    /* Image attention: img_Q @ cat_K^T -> softmax -> @ cat_V */
+    float attn_scale = 1.0f / sqrtf((float)head_dim);
+    if (!flux_rocm_gpu_attention_fused(img_attn_out_gpu, img_q_proj, cat_k_gpu, cat_v_gpu,
+                                       img_seq, total_seq, heads, head_dim, attn_scale)) {
+        /* Attention failed, cleanup and fallback */
+        flux_rocm_tensor_free(img_hidden_gpu);
+        flux_rocm_tensor_free(txt_hidden_gpu);
+        flux_rocm_tensor_free(img_norm_gpu);
+        flux_rocm_tensor_free(txt_norm_gpu);
+        flux_rocm_tensor_free(img_q_proj);
+        flux_rocm_tensor_free(img_k_proj);
+        flux_rocm_tensor_free(img_v_proj);
+        flux_rocm_tensor_free(txt_q_proj);
+        flux_rocm_tensor_free(txt_k_proj);
+        flux_rocm_tensor_free(txt_v_proj);
+        flux_rocm_tensor_free(cat_k_gpu);
+        flux_rocm_tensor_free(cat_v_gpu);
+        flux_rocm_tensor_free(img_attn_out_gpu);
+        flux_rocm_tensor_free(txt_attn_out_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* Text attention: txt_Q @ cat_K^T -> softmax -> @ cat_V */
+    if (!flux_rocm_gpu_attention_fused(txt_attn_out_gpu, txt_q_proj, cat_k_gpu, cat_v_gpu,
+                                       txt_seq, total_seq, heads, head_dim, attn_scale)) {
+        flux_rocm_tensor_free(img_hidden_gpu);
+        flux_rocm_tensor_free(txt_hidden_gpu);
+        flux_rocm_tensor_free(img_norm_gpu);
+        flux_rocm_tensor_free(txt_norm_gpu);
+        flux_rocm_tensor_free(img_q_proj);
+        flux_rocm_tensor_free(img_k_proj);
+        flux_rocm_tensor_free(img_v_proj);
+        flux_rocm_tensor_free(txt_q_proj);
+        flux_rocm_tensor_free(txt_k_proj);
+        flux_rocm_tensor_free(txt_v_proj);
+        flux_rocm_tensor_free(cat_k_gpu);
+        flux_rocm_tensor_free(cat_v_gpu);
+        flux_rocm_tensor_free(img_attn_out_gpu);
+        flux_rocm_tensor_free(txt_attn_out_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* === Project attention outputs and apply gated residual === */
+    flux_rocm_tensor_t img_proj_gpu = flux_rocm_gpu_linear(img_attn_out_gpu, block->img_proj_weight,
+                                                           img_seq, hidden, hidden);
+    flux_rocm_tensor_t txt_proj_gpu = flux_rocm_gpu_linear(txt_attn_out_gpu, block->txt_proj_weight,
+                                                           txt_seq, hidden, hidden);
+    
+    if (!img_proj_gpu || !txt_proj_gpu) {
+        flux_rocm_tensor_free(img_hidden_gpu);
+        flux_rocm_tensor_free(txt_hidden_gpu);
+        flux_rocm_tensor_free(img_norm_gpu);
+        flux_rocm_tensor_free(txt_norm_gpu);
+        flux_rocm_tensor_free(img_q_proj);
+        flux_rocm_tensor_free(img_k_proj);
+        flux_rocm_tensor_free(img_v_proj);
+        flux_rocm_tensor_free(txt_q_proj);
+        flux_rocm_tensor_free(txt_k_proj);
+        flux_rocm_tensor_free(txt_v_proj);
+        flux_rocm_tensor_free(cat_k_gpu);
+        flux_rocm_tensor_free(cat_v_gpu);
+        flux_rocm_tensor_free(img_attn_out_gpu);
+        flux_rocm_tensor_free(txt_attn_out_gpu);
+        if (img_proj_gpu) flux_rocm_tensor_free(img_proj_gpu);
+        if (txt_proj_gpu) flux_rocm_tensor_free(txt_proj_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    /* Gated residual: hidden += gate * proj */
+    flux_rocm_gpu_gated_add(img_hidden_gpu, img_gate1, img_proj_gpu, img_seq, hidden);
+    flux_rocm_gpu_gated_add(txt_hidden_gpu, txt_gate1, txt_proj_gpu, txt_seq, hidden);
+    
+    /* === FFN for image === */
+    flux_rocm_gpu_adaln_norm(img_norm_gpu, img_hidden_gpu, img_shift2, img_scale2,
+                             img_seq, hidden, eps);
+    
+    flux_rocm_tensor_t img_ffn_out = flux_rocm_gpu_swiglu_ffn(img_norm_gpu,
+                                                              block->img_mlp_gate_weight,
+                                                              block->img_mlp_up_weight,
+                                                              block->img_mlp_down_weight,
+                                                              img_seq, hidden, mlp_hidden);
+    
+    if (!img_ffn_out) {
+        /* FFN failed - cleanup all and fallback */
+        flux_rocm_tensor_free(img_hidden_gpu);
+        flux_rocm_tensor_free(txt_hidden_gpu);
+        flux_rocm_tensor_free(img_norm_gpu);
+        flux_rocm_tensor_free(txt_norm_gpu);
+        flux_rocm_tensor_free(img_q_proj);
+        flux_rocm_tensor_free(img_k_proj);
+        flux_rocm_tensor_free(img_v_proj);
+        flux_rocm_tensor_free(txt_q_proj);
+        flux_rocm_tensor_free(txt_k_proj);
+        flux_rocm_tensor_free(txt_v_proj);
+        flux_rocm_tensor_free(cat_k_gpu);
+        flux_rocm_tensor_free(cat_v_gpu);
+        flux_rocm_tensor_free(img_attn_out_gpu);
+        flux_rocm_tensor_free(txt_attn_out_gpu);
+        flux_rocm_tensor_free(img_proj_gpu);
+        flux_rocm_tensor_free(txt_proj_gpu);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    flux_rocm_gpu_gated_add(img_hidden_gpu, img_gate2, img_ffn_out, img_seq, hidden);
+    
+    /* === FFN for text === */
+    flux_rocm_gpu_adaln_norm(txt_norm_gpu, txt_hidden_gpu, txt_shift2, txt_scale2,
+                             txt_seq, hidden, eps);
+    
+    flux_rocm_tensor_t txt_ffn_out = flux_rocm_gpu_swiglu_ffn(txt_norm_gpu,
+                                                              block->txt_mlp_gate_weight,
+                                                              block->txt_mlp_up_weight,
+                                                              block->txt_mlp_down_weight,
+                                                              txt_seq, hidden, mlp_hidden);
+    
+    if (!txt_ffn_out) {
+        flux_rocm_tensor_free(img_hidden_gpu);
+        flux_rocm_tensor_free(txt_hidden_gpu);
+        flux_rocm_tensor_free(img_norm_gpu);
+        flux_rocm_tensor_free(txt_norm_gpu);
+        flux_rocm_tensor_free(img_q_proj);
+        flux_rocm_tensor_free(img_k_proj);
+        flux_rocm_tensor_free(img_v_proj);
+        flux_rocm_tensor_free(txt_q_proj);
+        flux_rocm_tensor_free(txt_k_proj);
+        flux_rocm_tensor_free(txt_v_proj);
+        flux_rocm_tensor_free(cat_k_gpu);
+        flux_rocm_tensor_free(cat_v_gpu);
+        flux_rocm_tensor_free(img_attn_out_gpu);
+        flux_rocm_tensor_free(txt_attn_out_gpu);
+        flux_rocm_tensor_free(img_proj_gpu);
+        flux_rocm_tensor_free(txt_proj_gpu);
+        flux_rocm_tensor_free(img_ffn_out);
+        flux_rocm_batch_end();
+        return 0;
+    }
+    
+    flux_rocm_gpu_gated_add(txt_hidden_gpu, txt_gate2, txt_ffn_out, txt_seq, hidden);
+    
+    /* === Sync and copy results back === */
+    flux_rocm_batch_end();
+    flux_rocm_tensor_read(img_hidden_gpu, img_hidden, img_seq * hidden);
+    flux_rocm_tensor_read(txt_hidden_gpu, txt_hidden, txt_seq * hidden);
+    
+    /* === Cleanup all tensors === */
+    flux_rocm_tensor_free(img_hidden_gpu);
+    flux_rocm_tensor_free(txt_hidden_gpu);
+    flux_rocm_tensor_free(img_norm_gpu);
+    flux_rocm_tensor_free(txt_norm_gpu);
+    flux_rocm_tensor_free(img_q_proj);
+    flux_rocm_tensor_free(img_k_proj);
+    flux_rocm_tensor_free(img_v_proj);
+    flux_rocm_tensor_free(txt_q_proj);
+    flux_rocm_tensor_free(txt_k_proj);
+    flux_rocm_tensor_free(txt_v_proj);
+    flux_rocm_tensor_free(cat_k_gpu);
+    flux_rocm_tensor_free(cat_v_gpu);
+    flux_rocm_tensor_free(img_attn_out_gpu);
+    flux_rocm_tensor_free(txt_attn_out_gpu);
+    flux_rocm_tensor_free(img_proj_gpu);
+    flux_rocm_tensor_free(txt_proj_gpu);
+    flux_rocm_tensor_free(img_ffn_out);
+    flux_rocm_tensor_free(txt_ffn_out);
+    
+    return 1;  /* GPU path succeeded */
+}
+#endif /* USE_ROCM */
+
 static void single_block_forward(float *hidden, const single_block_t *block,
                                  const float *t_emb, const float *adaln_weight,
                                  const float *img_rope_cos, const float *img_rope_sin,
@@ -2888,12 +3393,24 @@ float *flux_transformer_forward(flux_transformer_t *tf,
             load_double_block_weights(&tf->double_blocks[i], tf->sf, i,
                                       tf->hidden_size, tf->mlp_hidden, tf->use_bf16);
         }
-        double_block_forward(img_hidden, txt_hidden,
-                             &tf->double_blocks[i],
-                             tf->double_mod_img, tf->double_mod_txt,
-                             img_rope_cos, img_rope_sin,
-                             txt_rope_cos, txt_rope_sin,
-                             img_seq, txt_seq, tf);
+#ifdef USE_ROCM
+        /* Try GPU path first */
+        int gpu_done = double_block_forward_rocm(img_hidden, txt_hidden,
+                                                  &tf->double_blocks[i],
+                                                  tf->double_mod_img, tf->double_mod_txt,
+                                                  img_rope_cos, img_rope_sin,
+                                                  txt_rope_cos, txt_rope_sin,
+                                                  img_seq, txt_seq, tf);
+        if (!gpu_done)
+#endif
+        {
+            double_block_forward(img_hidden, txt_hidden,
+                                 &tf->double_blocks[i],
+                                 tf->double_mod_img, tf->double_mod_txt,
+                                 img_rope_cos, img_rope_sin,
+                                 txt_rope_cos, txt_rope_sin,
+                                 img_seq, txt_seq, tf);
+        }
         /* In mmap mode, free block weights after use */
         if (tf->use_mmap) {
             free_double_block_weights(&tf->double_blocks[i]);
@@ -3104,15 +3621,24 @@ float *flux_transformer_forward(flux_transformer_t *tf,
                 load_single_block_weights(&tf->single_blocks[i], tf->sf, i,
                                           tf->hidden_size, tf->mlp_hidden, tf->use_bf16);
             }
+{
+            int gpu_done = 0;
 #ifdef USE_METAL
             /* Try GPU-optimized path first */
-            if (!single_block_forward_gpu(concat_hidden, &tf->single_blocks[i],
+            gpu_done = single_block_forward_gpu(concat_hidden, &tf->single_blocks[i],
                                           t_emb, tf->adaln_single_weight,
                                           img_rope_cos, img_rope_sin,
                                           txt_rope_cos, txt_rope_sin,
-                                          total_seq, txt_seq, tf))
+                                          total_seq, txt_seq, tf);
+#elif defined(USE_ROCM)
+            /* Try ROCm GPU path */
+            gpu_done = single_block_forward_rocm(concat_hidden, &tf->single_blocks[i],
+                                           t_emb, tf->adaln_single_weight,
+                                           img_rope_cos, img_rope_sin,
+                                           txt_rope_cos, txt_rope_sin,
+                                           total_seq, txt_seq, tf);
 #endif
-            {
+            if (!gpu_done) {
                 /* Fall back to CPU path */
                 single_block_forward(concat_hidden, &tf->single_blocks[i],
                                      t_emb, tf->adaln_single_weight,
@@ -3125,6 +3651,7 @@ float *flux_transformer_forward(flux_transformer_t *tf,
                 free_single_block_weights(&tf->single_blocks[i]);
                 /* With direct mmap pointers for bf16, no need to clear caches. */
             }
+}
             if (flux_substep_callback)
                 flux_substep_callback(FLUX_SUBSTEP_SINGLE_BLOCK, i, tf->num_single_layers);
 
@@ -3356,12 +3883,23 @@ float *flux_transformer_forward_with_refs(flux_transformer_t *tf,
             load_double_block_weights(&tf->double_blocks[i], tf->sf, i,
                                       tf->hidden_size, tf->mlp_hidden, tf->use_bf16);
         }
-        double_block_forward(combined_hidden, txt_hidden,
-                             &tf->double_blocks[i],
-                             tf->double_mod_img, tf->double_mod_txt,
-                             combined_rope_cos, combined_rope_sin,
-                             txt_rope_cos, txt_rope_sin,
-                             combined_img_seq, txt_seq, tf);
+#ifdef USE_ROCM
+        int gpu_done = double_block_forward_rocm(combined_hidden, txt_hidden,
+                                                  &tf->double_blocks[i],
+                                                  tf->double_mod_img, tf->double_mod_txt,
+                                                  combined_rope_cos, combined_rope_sin,
+                                                  txt_rope_cos, txt_rope_sin,
+                                                  combined_img_seq, txt_seq, tf);
+        if (!gpu_done)
+#endif
+        {
+            double_block_forward(combined_hidden, txt_hidden,
+                                 &tf->double_blocks[i],
+                                 tf->double_mod_img, tf->double_mod_txt,
+                                 combined_rope_cos, combined_rope_sin,
+                                 txt_rope_cos, txt_rope_sin,
+                                 combined_img_seq, txt_seq, tf);
+        }
         if (tf->use_mmap) {
             free_double_block_weights(&tf->double_blocks[i]);
             /* With direct mmap pointers for bf16, no need to clear caches. */
@@ -3584,12 +4122,23 @@ float *flux_transformer_forward_with_multi_refs(flux_transformer_t *tf,
             load_double_block_weights(&tf->double_blocks[i], tf->sf, i,
                                       tf->hidden_size, tf->mlp_hidden, tf->use_bf16);
         }
-        double_block_forward(combined_hidden, txt_hidden,
-                             &tf->double_blocks[i],
-                             tf->double_mod_img, tf->double_mod_txt,
-                             combined_rope_cos, combined_rope_sin,
-                             txt_rope_cos, txt_rope_sin,
-                             combined_img_seq, txt_seq, tf);
+#ifdef USE_ROCM
+        int gpu_done = double_block_forward_rocm(combined_hidden, txt_hidden,
+                                                  &tf->double_blocks[i],
+                                                  tf->double_mod_img, tf->double_mod_txt,
+                                                  combined_rope_cos, combined_rope_sin,
+                                                  txt_rope_cos, txt_rope_sin,
+                                                  combined_img_seq, txt_seq, tf);
+        if (!gpu_done)
+#endif
+        {
+            double_block_forward(combined_hidden, txt_hidden,
+                                 &tf->double_blocks[i],
+                                 tf->double_mod_img, tf->double_mod_txt,
+                                 combined_rope_cos, combined_rope_sin,
+                                 txt_rope_cos, txt_rope_sin,
+                                 combined_img_seq, txt_seq, tf);
+        }
         if (tf->use_mmap) {
             free_double_block_weights(&tf->double_blocks[i]);
         }

--- a/main.c
+++ b/main.c
@@ -627,6 +627,9 @@ int main(int argc, char *argv[]) {
 #ifdef USE_METAL
     flux_metal_cleanup();
 #endif
+#ifdef USE_ROCM
+    flux_rocm_cleanup();
+#endif
 
     return 0;
 }

--- a/main.c
+++ b/main.c
@@ -35,6 +35,10 @@
 #include "flux_metal.h"
 #endif
 
+#ifdef USE_ROCM
+#include "rocm/flux_rocm.h"
+#endif
+
 /* ========================================================================
  * Verbosity Levels
  * ======================================================================== */
@@ -239,6 +243,12 @@ static void print_usage(const char *prog) {
 int main(int argc, char *argv[]) {
 #ifdef USE_METAL
     flux_metal_init();
+#elif defined(USE_ROCM)
+    if (flux_rocm_init()) {
+        /* ROCm initialized successfully - message printed by init */
+    } else {
+        fprintf(stderr, "ROCm: Falling back to BLAS\n");
+    }
 #elif defined(USE_BLAS)
     fprintf(stderr, "BLAS: CPU acceleration enabled (Accelerate/OpenBLAS)\n");
 #else

--- a/rocm/Makefile
+++ b/rocm/Makefile
@@ -1,0 +1,66 @@
+# ROCm Backend Build
+# 
+# Usage:
+#   make test        - Build and run all tests
+#   make test-basic  - Build and run infrastructure test only
+#   make test-kernel - Build and run kernel test
+#   make clean       - Clean build artifacts
+
+HIPCC = hipcc
+CXXFLAGS = -O3 -fPIC -std=c++17
+LDFLAGS = -lhipblas
+
+# Auto-detect GPU architecture
+GPU_ARCH := $(shell rocminfo 2>/dev/null | grep -o 'gfx[0-9]*' | head -1)
+ifeq ($(GPU_ARCH),)
+GPU_ARCH = native
+endif
+HIPCC_FLAGS = --offload-arch=$(GPU_ARCH)
+
+.PHONY: all test test-basic test-kernel clean info
+
+all: test_rocm test_kernels
+
+info:
+	@echo "GPU Architecture: $(GPU_ARCH)"
+	@echo "HIPCC: $(HIPCC)"
+	@hipcc --version
+
+# Infrastructure test (BLAS only)
+test_rocm: test_rocm.cpp flux_rocm.cpp flux_rocm.h
+	$(HIPCC) $(CXXFLAGS) $(HIPCC_FLAGS) -o $@ test_rocm.cpp flux_rocm.cpp $(LDFLAGS)
+
+# Kernel test (includes custom kernels)
+test_kernels: test_kernels.cpp flux_rocm.cpp flux_rocm_kernels.hip flux_rocm.h
+	$(HIPCC) $(CXXFLAGS) $(HIPCC_FLAGS) -o $@ test_kernels.cpp flux_rocm.cpp flux_rocm_kernels.hip $(LDFLAGS)
+
+test: test_rocm test_kernels
+	@echo "=== Running infrastructure test ==="
+	./test_rocm
+	@echo ""
+	@echo "=== Running kernel test ==="
+	./test_kernels
+
+test-basic: test_rocm
+	./test_rocm
+
+test-kernel: test_kernels
+	./test_kernels
+
+# Build library objects (for integration)
+flux_rocm.o: flux_rocm.cpp flux_rocm.h
+	$(HIPCC) $(CXXFLAGS) $(HIPCC_FLAGS) -c -o $@ flux_rocm.cpp
+
+flux_rocm_kernels.o: flux_rocm_kernels.hip flux_rocm.h
+	$(HIPCC) $(CXXFLAGS) $(HIPCC_FLAGS) -c -o $@ flux_rocm_kernels.hip
+
+flux_rocm_compat.o: flux_rocm_compat.cpp flux_rocm_compat.h flux_rocm.h
+	$(HIPCC) $(CXXFLAGS) $(HIPCC_FLAGS) -c -o $@ flux_rocm_compat.cpp
+
+# Full library for integration
+lib: flux_rocm.o flux_rocm_kernels.o flux_rocm_compat.o
+	ar rcs libflux_rocm.a flux_rocm.o flux_rocm_kernels.o flux_rocm_compat.o
+	@echo "Built libflux_rocm.a"
+
+clean:
+	rm -f test_rocm test_kernels *.o *.a

--- a/rocm/flux_rocm.cpp
+++ b/rocm/flux_rocm.cpp
@@ -1,0 +1,711 @@
+/*
+ * FLUX ROCm Acceleration - Core Implementation
+ *
+ * GPU infrastructure for AMD GPUs using HIP/ROCm.
+ * Key design: keep data on GPU, minimize PCIe transfers.
+ */
+
+#include "flux_rocm.h"
+#include <hip/hip_runtime.h>
+#include <hipblas/hipblas.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vector>
+#include <unordered_map>
+#include <mutex>
+
+/* ========================================================================
+ * Error Handling
+ * ======================================================================== */
+
+#define HIP_CHECK(call) do { \
+    hipError_t err = (call); \
+    if (err != hipSuccess) { \
+        fprintf(stderr, "HIP Error: %s at %s:%d\n", \
+                hipGetErrorString(err), __FILE__, __LINE__); \
+        return; \
+    } \
+} while(0)
+
+#define HIP_CHECK_RET(call, ret) do { \
+    hipError_t err = (call); \
+    if (err != hipSuccess) { \
+        fprintf(stderr, "HIP Error: %s at %s:%d\n", \
+                hipGetErrorString(err), __FILE__, __LINE__); \
+        return (ret); \
+    } \
+} while(0)
+
+#define HIPBLAS_CHECK(call) do { \
+    hipblasStatus_t status = (call); \
+    if (status != HIPBLAS_STATUS_SUCCESS) { \
+        fprintf(stderr, "hipBLAS Error: %d at %s:%d\n", \
+                (int)status, __FILE__, __LINE__); \
+    } \
+} while(0)
+
+/* ========================================================================
+ * Global State
+ * ======================================================================== */
+
+static int g_initialized = 0;
+static hipDevice_t g_device = 0;
+static hipStream_t g_stream = nullptr;
+static hipblasHandle_t g_hipblas = nullptr;
+
+/* Memory tracking */
+static size_t g_memory_used = 0;
+static std::mutex g_mutex;
+
+/* ========================================================================
+ * GPU Tensor Implementation
+ * ======================================================================== */
+
+struct flux_rocm_tensor {
+    void *data;           /* GPU pointer */
+    size_t num_elements;
+    size_t bytes;
+    int is_bf16;          /* 1 if bf16, 0 if f32 */
+    int persistent;       /* Don't return to pool */
+    int ref_count;
+};
+
+/* Simple buffer pool - maps size to list of free buffers */
+static std::unordered_map<size_t, std::vector<void*>> g_buffer_pool;
+static std::mutex g_pool_mutex;
+
+static void* pool_alloc(size_t bytes) {
+    std::lock_guard<std::mutex> lock(g_pool_mutex);
+    
+    auto it = g_buffer_pool.find(bytes);
+    if (it != g_buffer_pool.end() && !it->second.empty()) {
+        void *ptr = it->second.back();
+        it->second.pop_back();
+        return ptr;
+    }
+    
+    /* Allocate new buffer */
+    void *ptr = nullptr;
+    hipError_t err = hipMalloc(&ptr, bytes);
+    if (err != hipSuccess) {
+        fprintf(stderr, "hipMalloc failed for %zu bytes: %s\n", 
+                bytes, hipGetErrorString(err));
+        return nullptr;
+    }
+    
+    g_memory_used += bytes;
+    return ptr;
+}
+
+static void pool_free(void *ptr, size_t bytes) {
+    if (!ptr) return;
+    
+    std::lock_guard<std::mutex> lock(g_pool_mutex);
+    g_buffer_pool[bytes].push_back(ptr);
+}
+
+static void pool_clear() {
+    std::lock_guard<std::mutex> lock(g_pool_mutex);
+    
+    for (auto &kv : g_buffer_pool) {
+        for (void *ptr : kv.second) {
+            hipFree(ptr);
+            g_memory_used -= kv.first;
+        }
+    }
+    g_buffer_pool.clear();
+}
+
+/* ========================================================================
+ * Weight Cache - Keep model weights on GPU
+ * ======================================================================== */
+
+struct weight_cache_entry {
+    void *gpu_ptr;
+    size_t bytes;
+};
+
+static std::unordered_map<const void*, weight_cache_entry> g_weight_cache;
+static std::mutex g_weight_mutex;
+
+/* Get or upload weight tensor to GPU */
+/* Exposed for compat layer */
+void* get_cached_weight(const void *cpu_ptr, size_t bytes) {
+    std::lock_guard<std::mutex> lock(g_weight_mutex);
+    
+    auto it = g_weight_cache.find(cpu_ptr);
+    if (it != g_weight_cache.end()) {
+        return it->second.gpu_ptr;
+    }
+    
+    /* Upload to GPU */
+    void *gpu_ptr = nullptr;
+    hipError_t err = hipMalloc(&gpu_ptr, bytes);
+    if (err != hipSuccess) {
+        fprintf(stderr, "Weight cache: hipMalloc failed for %zu bytes\n", bytes);
+        return nullptr;
+    }
+    
+    err = hipMemcpy(gpu_ptr, cpu_ptr, bytes, hipMemcpyHostToDevice);
+    if (err != hipSuccess) {
+        fprintf(stderr, "Weight cache: hipMemcpy failed\n");
+        hipFree(gpu_ptr);
+        return nullptr;
+    }
+    
+    g_weight_cache[cpu_ptr] = {gpu_ptr, bytes};
+    g_memory_used += bytes;
+    
+    return gpu_ptr;
+}
+
+static void weight_cache_clear() {
+    std::lock_guard<std::mutex> lock(g_weight_mutex);
+    
+    for (auto &kv : g_weight_cache) {
+        hipFree(kv.second.gpu_ptr);
+        g_memory_used -= kv.second.bytes;
+    }
+    g_weight_cache.clear();
+}
+
+/* ========================================================================
+ * Initialization / Cleanup
+ * ======================================================================== */
+
+extern "C" int flux_rocm_init(void) {
+    if (g_initialized) return 1;
+    
+    /* Check for HIP devices */
+    int device_count = 0;
+    hipError_t err = hipGetDeviceCount(&device_count);
+    if (err != hipSuccess || device_count == 0) {
+        fprintf(stderr, "ROCm: No HIP devices found\n");
+        return 0;
+    }
+    
+    /* Use first device */
+    err = hipSetDevice(0);
+    if (err != hipSuccess) {
+        fprintf(stderr, "ROCm: Failed to set device\n");
+        return 0;
+    }
+    
+    /* Get device info */
+    hipDeviceProp_t props;
+    hipGetDeviceProperties(&props, 0);
+    fprintf(stderr, "ROCm: Using %s (%s, %zu MB VRAM)\n",
+            props.name, props.gcnArchName, props.totalGlobalMem / (1024*1024));
+    
+    /* Create stream */
+    err = hipStreamCreate(&g_stream);
+    if (err != hipSuccess) {
+        fprintf(stderr, "ROCm: Failed to create stream\n");
+        return 0;
+    }
+    
+    /* Initialize hipBLAS */
+    hipblasStatus_t blas_status = hipblasCreate(&g_hipblas);
+    if (blas_status != HIPBLAS_STATUS_SUCCESS) {
+        fprintf(stderr, "ROCm: Failed to initialize hipBLAS\n");
+        hipStreamDestroy(g_stream);
+        return 0;
+    }
+    
+    /* Associate hipBLAS with our stream */
+    hipblasSetStream(g_hipblas, g_stream);
+    
+    g_initialized = 1;
+    fprintf(stderr, "ROCm: Acceleration enabled\n");
+    return 1;
+}
+
+extern "C" int flux_rocm_available(void) {
+    return g_initialized;
+}
+
+extern "C" void flux_rocm_cleanup(void) {
+    if (!g_initialized) return;
+    
+    pool_clear();
+    weight_cache_clear();
+    
+    if (g_hipblas) {
+        hipblasDestroy(g_hipblas);
+        g_hipblas = nullptr;
+    }
+    
+    if (g_stream) {
+        hipStreamDestroy(g_stream);
+        g_stream = nullptr;
+    }
+    
+    g_initialized = 0;
+}
+
+extern "C" void flux_rocm_reset(void) {
+    pool_clear();
+    /* Note: Don't clear weight cache - weights should persist */
+}
+
+extern "C" void flux_rocm_sync(void) {
+    if (g_stream) {
+        hipStreamSynchronize(g_stream);
+    }
+}
+
+extern "C" size_t flux_rocm_memory_used(void) {
+    return g_memory_used;
+}
+
+/* ========================================================================
+ * GPU Tensor API
+ * ======================================================================== */
+
+extern "C" flux_rocm_tensor_t flux_rocm_tensor_create(const float *data, size_t num_elements) {
+    if (!g_initialized) return nullptr;
+    
+    flux_rocm_tensor *t = new flux_rocm_tensor;
+    t->num_elements = num_elements;
+    t->bytes = num_elements * sizeof(float);
+    t->is_bf16 = 0;
+    t->persistent = 0;
+    t->ref_count = 1;
+    
+    t->data = pool_alloc(t->bytes);
+    if (!t->data) {
+        delete t;
+        return nullptr;
+    }
+    
+    hipError_t err = hipMemcpyAsync(t->data, data, t->bytes, 
+                                     hipMemcpyHostToDevice, g_stream);
+    if (err != hipSuccess) {
+        pool_free(t->data, t->bytes);
+        delete t;
+        return nullptr;
+    }
+    
+    return t;
+}
+
+extern "C" flux_rocm_tensor_t flux_rocm_tensor_alloc(size_t num_elements) {
+    if (!g_initialized) return nullptr;
+    
+    flux_rocm_tensor *t = new flux_rocm_tensor;
+    t->num_elements = num_elements;
+    t->bytes = num_elements * sizeof(float);
+    t->is_bf16 = 0;
+    t->persistent = 0;
+    t->ref_count = 1;
+    
+    t->data = pool_alloc(t->bytes);
+    if (!t->data) {
+        delete t;
+        return nullptr;
+    }
+    
+    return t;
+}
+
+extern "C" flux_rocm_tensor_t flux_rocm_tensor_alloc_persistent(size_t num_elements) {
+    flux_rocm_tensor_t t = flux_rocm_tensor_alloc(num_elements);
+    if (t) t->persistent = 1;
+    return t;
+}
+
+extern "C" void flux_rocm_tensor_set_persistent(flux_rocm_tensor_t tensor, int persistent) {
+    if (tensor) tensor->persistent = persistent;
+}
+
+extern "C" void flux_rocm_tensor_read(flux_rocm_tensor_t tensor, float *out, size_t num_elements) {
+    if (!tensor || !out) return;
+    
+    size_t bytes = num_elements * sizeof(float);
+    if (bytes > tensor->bytes) bytes = tensor->bytes;
+    
+    hipMemcpyAsync(out, tensor->data, bytes, hipMemcpyDeviceToHost, g_stream);
+    hipStreamSynchronize(g_stream);  /* Must sync for CPU to see data */
+}
+
+extern "C" void flux_rocm_tensor_write(flux_rocm_tensor_t tensor, const float *data, size_t num_elements) {
+    if (!tensor || !data) return;
+    
+    size_t bytes = num_elements * sizeof(float);
+    if (bytes > tensor->bytes) bytes = tensor->bytes;
+    
+    hipMemcpyAsync(tensor->data, data, bytes, hipMemcpyHostToDevice, g_stream);
+}
+
+extern "C" void flux_rocm_tensor_free(flux_rocm_tensor_t tensor) {
+    if (!tensor) return;
+    
+    if (!tensor->persistent) {
+        pool_free(tensor->data, tensor->bytes);
+    }
+    delete tensor;
+}
+
+extern "C" size_t flux_rocm_tensor_size(flux_rocm_tensor_t tensor) {
+    return tensor ? tensor->num_elements : 0;
+}
+
+extern "C" int flux_rocm_tensor_is_bf16(flux_rocm_tensor_t tensor) {
+    return tensor ? tensor->is_bf16 : 0;
+}
+
+extern "C" void *flux_rocm_tensor_gpu_ptr(flux_rocm_tensor_t tensor) {
+    return tensor ? tensor->data : nullptr;
+}
+
+extern "C" flux_rocm_tensor_t flux_rocm_tensor_alloc_bf16(size_t num_elements) {
+    if (!g_initialized) return nullptr;
+    
+    flux_rocm_tensor *t = new flux_rocm_tensor;
+    t->num_elements = num_elements;
+    t->bytes = num_elements * sizeof(uint16_t);  /* bf16 = 2 bytes */
+    t->is_bf16 = 1;
+    t->persistent = 0;
+    t->ref_count = 1;
+    
+    t->data = pool_alloc(t->bytes);
+    if (!t->data) {
+        delete t;
+        return nullptr;
+    }
+    
+    return t;
+}
+
+/* ========================================================================
+ * BLAS Operations (hipBLAS)
+ * ======================================================================== */
+
+/* Internal helper: get GPU pointer for data (from cache or tensor) */
+static float* get_gpu_ptr(const float *cpu_or_gpu, size_t bytes, bool is_weight) {
+    /* TODO: Detect if pointer is already on GPU */
+    /* For now, assume weights need caching, activations are already GPU tensors */
+    if (is_weight) {
+        return (float*)get_cached_weight(cpu_or_gpu, bytes);
+    }
+    return (float*)cpu_or_gpu;  /* Assume already on GPU */
+}
+
+extern "C" void flux_rocm_sgemm(int transpose_a, int transpose_b,
+                                int M, int N, int K,
+                                float alpha,
+                                const float *A, int lda,
+                                const float *B, int ldb,
+                                float beta,
+                                float *C, int ldc) {
+    if (!g_initialized || !g_hipblas) return;
+    
+    /* hipBLAS uses column-major, so we swap A and B */
+    hipblasOperation_t opA = transpose_b ? HIPBLAS_OP_T : HIPBLAS_OP_N;
+    hipblasOperation_t opB = transpose_a ? HIPBLAS_OP_T : HIPBLAS_OP_N;
+    
+    /* Note: For row-major C = A @ B, we compute C^T = B^T @ A^T in col-major */
+    HIPBLAS_CHECK(hipblasSgemm(g_hipblas,
+                               opA, opB,
+                               N, M, K,
+                               &alpha,
+                               B, ldb,
+                               A, lda,
+                               &beta,
+                               C, ldc));
+}
+
+extern "C" void flux_rocm_sgemm_batch(int transpose_a, int transpose_b,
+                                      int M, int N, int K,
+                                      float alpha,
+                                      const float *A, int lda, int stride_a,
+                                      const float *B, int ldb, int stride_b,
+                                      float beta,
+                                      float *C, int ldc, int stride_c,
+                                      int batch_count) {
+    if (!g_initialized || !g_hipblas) return;
+    
+    hipblasOperation_t opA = transpose_b ? HIPBLAS_OP_T : HIPBLAS_OP_N;
+    hipblasOperation_t opB = transpose_a ? HIPBLAS_OP_T : HIPBLAS_OP_N;
+    
+    HIPBLAS_CHECK(hipblasSgemmStridedBatched(g_hipblas,
+                                             opA, opB,
+                                             N, M, K,
+                                             &alpha,
+                                             B, ldb, stride_b,
+                                             A, lda, stride_a,
+                                             &beta,
+                                             C, ldc, stride_c,
+                                             batch_count));
+}
+
+/* ========================================================================
+ * Linear Layer
+ * ======================================================================== */
+
+extern "C" flux_rocm_tensor_t flux_rocm_linear(flux_rocm_tensor_t x,
+                                               const float *W,
+                                               int seq_len, int in_dim, int out_dim) {
+    if (!g_initialized || !x) return nullptr;
+    
+    /* Allocate output */
+    flux_rocm_tensor_t out = flux_rocm_tensor_alloc(seq_len * out_dim);
+    if (!out) return nullptr;
+    
+    /* Get weight on GPU (cached) */
+    float *W_gpu = (float*)get_cached_weight(W, out_dim * in_dim * sizeof(float));
+    if (!W_gpu) {
+        flux_rocm_tensor_free(out);
+        return nullptr;
+    }
+    
+    /* out = x @ W^T */
+    /* x: [seq, in_dim], W: [out_dim, in_dim], out: [seq, out_dim] */
+    flux_rocm_sgemm(0, 1,  /* no trans A, trans B */
+                    seq_len, out_dim, in_dim,
+                    1.0f,
+                    (float*)x->data, in_dim,
+                    W_gpu, in_dim,
+                    0.0f,
+                    (float*)out->data, out_dim);
+    
+    return out;
+}
+
+extern "C" flux_rocm_tensor_t flux_rocm_linear_bf16(flux_rocm_tensor_t x,
+                                                    const uint16_t *W_bf16,
+                                                    int seq_len, int in_dim, int out_dim) {
+    /* TODO: Implement bf16 GEMM using hipblasGemmEx or custom kernel */
+    /* For now, fall back to f32 by converting weights */
+    fprintf(stderr, "ROCm: bf16 linear not yet implemented, using f32 fallback\n");
+    
+    /* This is inefficient but gets us started */
+    /* In production, use hipblasGemmEx with HIPBLAS_R_16BF */
+    return nullptr;
+}
+
+/* ========================================================================
+ * Batch/Chain API (Placeholder)
+ * ======================================================================== */
+
+static int g_in_batch = 0;
+static int g_in_chain = 0;
+
+extern "C" void flux_rocm_batch_begin(void) { g_in_batch = 1; }
+extern "C" void flux_rocm_batch_end(void) { 
+    g_in_batch = 0; 
+    flux_rocm_sync();
+}
+extern "C" int flux_rocm_in_batch(void) { return g_in_batch; }
+
+extern "C" void flux_rocm_chain_begin(void) { g_in_chain = 1; }
+extern "C" void flux_rocm_chain_end(void) { 
+    g_in_chain = 0; 
+    flux_rocm_sync();
+}
+extern "C" int flux_rocm_in_chain(void) { return g_in_chain; }
+
+/* ========================================================================
+ * Stub implementations (to be filled in)
+ * ======================================================================== */
+
+extern "C" int flux_rocm_kernels_available(void) {
+    return g_initialized;  /* Will be true once we add kernels */
+}
+
+extern "C" void flux_rocm_warmup_bf16(const uint16_t *bf16_weights, size_t num_elements) {
+    /* Pre-upload bf16 weights to GPU */
+    get_cached_weight(bf16_weights, num_elements * sizeof(uint16_t));
+}
+
+extern "C" int flux_rocm_bf16_available(void) {
+    /* RDNA 3+ has good bf16 support */
+    return g_initialized;
+}
+
+/* ========================================================================
+ * Kernel declarations (from flux_rocm_kernels.hip)
+ * ======================================================================== */
+
+extern "C" {
+void flux_rocm_kernel_silu(float *x, int n, hipStream_t stream);
+void flux_rocm_kernel_silu_mul(float *gate, const float *up, int n, hipStream_t stream);
+void flux_rocm_kernel_rms_norm(float *out, const float *x, const float *weight,
+                               int seq_len, int hidden, float eps, hipStream_t stream);
+void flux_rocm_kernel_qk_rms_norm(float *q, float *k,
+                                  const float *q_weight, const float *k_weight,
+                                  int seq, int heads, int head_dim, float eps, hipStream_t stream);
+void flux_rocm_kernel_adaln_norm(float *out, const float *x,
+                                 const float *shift, const float *scale,
+                                 int seq_len, int hidden, float eps, hipStream_t stream);
+void flux_rocm_kernel_softmax(float *x, int rows, int cols, hipStream_t stream);
+void flux_rocm_kernel_gated_add(float *out, const float *gate, const float *proj,
+                                int seq, int hidden, hipStream_t stream);
+void flux_rocm_kernel_rope_2d(float *x, const float *cos_freq, const float *sin_freq,
+                              int seq, int heads, int head_dim, int axis_dim, hipStream_t stream);
+void flux_rocm_kernel_rope_unified(float *q, float *k,
+                                   const float *txt_cos, const float *txt_sin,
+                                   const float *img_cos, const float *img_sin,
+                                   int seq, int img_offset, int heads, int head_dim, int axis_dim,
+                                   hipStream_t stream);
+void flux_rocm_kernel_transpose_to_heads(float *out, const float *in,
+                                         int seq, int heads, int head_dim,
+                                         hipStream_t stream);
+void flux_rocm_kernel_transpose_from_heads(float *out, const float *in,
+                                           int seq, int heads, int head_dim,
+                                           hipStream_t stream);
+}
+
+/* Helper to get the global stream */
+hipStream_t get_stream() { return g_stream; }
+
+/* ========================================================================
+ * Kernel Wrappers
+ * ======================================================================== */
+
+extern "C" void flux_rocm_rms_norm(float *out, const float *x, const float *weight,
+                                   int seq_len, int hidden, float eps) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_rms_norm(out, x, weight, seq_len, hidden, eps, g_stream);
+}
+
+extern "C" void flux_rocm_qk_rms_norm(float *q, float *k,
+                                      const float *q_weight, const float *k_weight,
+                                      int seq, int heads, int head_dim, float eps) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_qk_rms_norm(q, k, q_weight, k_weight, seq, heads, head_dim, eps, g_stream);
+}
+
+extern "C" void flux_rocm_adaln_norm(float *out, const float *x,
+                                     const float *shift, const float *scale,
+                                     int seq_len, int hidden, float eps) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_adaln_norm(out, x, shift, scale, seq_len, hidden, eps, g_stream);
+}
+
+extern "C" void flux_rocm_silu(float *x, int n) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_silu(x, n, g_stream);
+}
+
+extern "C" void flux_rocm_silu_mul(float *gate, const float *up, int n) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_silu_mul(gate, up, n, g_stream);
+}
+
+extern "C" void flux_rocm_softmax(float *x, int rows, int cols) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_softmax(x, rows, cols, g_stream);
+}
+
+extern "C" void flux_rocm_gated_add(float *out, const float *gate,
+                                    const float *proj, int seq, int hidden) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_gated_add(out, gate, proj, seq, hidden, g_stream);
+}
+
+extern "C" void flux_rocm_rope_2d(float *x, const float *cos_freq, const float *sin_freq,
+                                  int seq, int heads, int head_dim, int axis_dim) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_rope_2d(x, cos_freq, sin_freq, seq, heads, head_dim, axis_dim, g_stream);
+}
+
+extern "C" void flux_rocm_rope_unified(float *q, float *k,
+                                       const float *txt_cos, const float *txt_sin,
+                                       const float *img_cos, const float *img_sin,
+                                       int seq, int img_offset, int heads, int head_dim, int axis_dim) {
+    if (!g_initialized) return;
+    flux_rocm_kernel_rope_unified(q, k, txt_cos, txt_sin, img_cos, img_sin,
+                                  seq, img_offset, heads, head_dim, axis_dim, g_stream);
+}
+
+/*
+ * Attention using batched GEMM.
+ * 
+ * Q, K, V: [seq, num_heads * head_dim] (input layout)
+ * out: [seq, num_heads * head_dim]
+ * 
+ * Internally we transpose to [num_heads, seq, head_dim] for batched ops.
+ */
+extern "C" int flux_rocm_attention_fused(float *out,
+                                         const float *Q, const float *K, const float *V,
+                                         int seq_q, int seq_k, int num_heads, int head_dim,
+                                         float scale) {
+    if (!g_initialized || !g_hipblas) return 0;
+    
+    int hidden = num_heads * head_dim;
+    
+    /* Allocate workspace for transposed tensors and scores */
+    size_t qkv_size = num_heads * seq_q * head_dim;
+    size_t scores_size = num_heads * seq_q * seq_k;
+    
+    float *Q_t = (float*)pool_alloc(qkv_size * sizeof(float));
+    float *K_t = (float*)pool_alloc(num_heads * seq_k * head_dim * sizeof(float));
+    float *V_t = (float*)pool_alloc(num_heads * seq_k * head_dim * sizeof(float));
+    float *scores = (float*)pool_alloc(scores_size * sizeof(float));
+    float *out_t = (float*)pool_alloc(qkv_size * sizeof(float));
+    
+    if (!Q_t || !K_t || !V_t || !scores || !out_t) {
+        if (Q_t) pool_free(Q_t, qkv_size * sizeof(float));
+        if (K_t) pool_free(K_t, num_heads * seq_k * head_dim * sizeof(float));
+        if (V_t) pool_free(V_t, num_heads * seq_k * head_dim * sizeof(float));
+        if (scores) pool_free(scores, scores_size * sizeof(float));
+        if (out_t) pool_free(out_t, qkv_size * sizeof(float));
+        return 0;
+    }
+    
+    /* GPU Transpose: [seq, heads*head_dim] -> [heads, seq, head_dim] */
+    flux_rocm_kernel_transpose_to_heads(Q_t, Q, seq_q, num_heads, head_dim, g_stream);
+    flux_rocm_kernel_transpose_to_heads(K_t, K, seq_k, num_heads, head_dim, g_stream);
+    flux_rocm_kernel_transpose_to_heads(V_t, V, seq_k, num_heads, head_dim, g_stream);
+    
+    /* Batched GEMM 1: scores = Q @ K^T
+     * Q_t: [heads, seq_q, head_dim]
+     * K_t: [heads, seq_k, head_dim]
+     * scores: [heads, seq_q, seq_k]
+     */
+    float alpha = scale;
+    float beta = 0.0f;
+    
+    HIPBLAS_CHECK(hipblasSgemmStridedBatched(g_hipblas,
+        HIPBLAS_OP_T, HIPBLAS_OP_N,  /* K^T @ Q in col-major = Q @ K^T in row-major */
+        seq_k, seq_q, head_dim,
+        &alpha,
+        K_t, head_dim, seq_k * head_dim,
+        Q_t, head_dim, seq_q * head_dim,
+        &beta,
+        scores, seq_k, seq_q * seq_k,
+        num_heads));
+    
+    /* Softmax on scores */
+    flux_rocm_kernel_softmax(scores, num_heads * seq_q, seq_k, g_stream);
+    
+    /* Batched GEMM 2: out = scores @ V
+     * scores: [heads, seq_q, seq_k]
+     * V_t: [heads, seq_k, head_dim]
+     * out_t: [heads, seq_q, head_dim]
+     */
+    alpha = 1.0f;
+    HIPBLAS_CHECK(hipblasSgemmStridedBatched(g_hipblas,
+        HIPBLAS_OP_N, HIPBLAS_OP_N,  /* V @ scores^T in col-major = scores @ V in row-major */
+        head_dim, seq_q, seq_k,
+        &alpha,
+        V_t, head_dim, seq_k * head_dim,
+        scores, seq_k, seq_q * seq_k,
+        &beta,
+        out_t, head_dim, seq_q * head_dim,
+        num_heads));
+    
+    /* GPU Transpose output back: [heads, seq, head_dim] -> [seq, heads*head_dim] */
+    flux_rocm_kernel_transpose_from_heads(out, out_t, seq_q, num_heads, head_dim, g_stream);
+    
+    /* Cleanup */
+    pool_free(Q_t, qkv_size * sizeof(float));
+    pool_free(K_t, num_heads * seq_k * head_dim * sizeof(float));
+    pool_free(V_t, num_heads * seq_k * head_dim * sizeof(float));
+    pool_free(scores, scores_size * sizeof(float));
+    pool_free(out_t, qkv_size * sizeof(float));
+    
+    return 1;
+}

--- a/rocm/flux_rocm.h
+++ b/rocm/flux_rocm.h
@@ -324,6 +324,35 @@ void flux_rocm_gpu_split_qkv_mlp(flux_rocm_tensor_t fused,
 void flux_rocm_gpu_concat_attn_mlp(flux_rocm_tensor_t attn, flux_rocm_tensor_t mlp,
                                    flux_rocm_tensor_t out, int seq, int hidden, int mlp_hidden);
 
+/* Linear layer on GPU tensors - returns new tensor */
+flux_rocm_tensor_t flux_rocm_gpu_linear(flux_rocm_tensor_t x, const float *W,
+                                        int seq_len, int in_dim, int out_dim);
+
+/* ========================================================================
+ * Double Block Support (GPU tensor operations)
+ * ======================================================================== */
+
+/* RoPE 2D on single tensor (for separate img/txt RoPE) */
+void flux_rocm_gpu_rope_2d(flux_rocm_tensor_t x,
+                           const float *cos_freq, const float *sin_freq,
+                           int seq, int heads, int head_dim);
+
+/* Concatenate K or V tensors from img and txt streams
+ * Order: [txt, img] (matches Python Flux2 implementation)
+ */
+void flux_rocm_gpu_concat_tensors(flux_rocm_tensor_t txt, flux_rocm_tensor_t img,
+                                  flux_rocm_tensor_t out,
+                                  int txt_seq, int img_seq, int hidden);
+
+/* SwiGLU FFN: out = down(silu(gate(x)) * up(x))
+ * All three projections executed on GPU
+ */
+flux_rocm_tensor_t flux_rocm_gpu_swiglu_ffn(flux_rocm_tensor_t x,
+                                            const float *gate_weight,
+                                            const float *up_weight,
+                                            const float *down_weight,
+                                            int seq, int hidden, int mlp_hidden);
+
 /* ========================================================================
  * Batch/Chain API (for operation fusion)
  * ======================================================================== */

--- a/rocm/flux_rocm.h
+++ b/rocm/flux_rocm.h
@@ -1,0 +1,384 @@
+/*
+ * FLUX ROCm Acceleration
+ *
+ * GPU-accelerated operations using AMD ROCm/HIP.
+ * Mirrors flux_metal.h API for drop-in replacement.
+ */
+
+#ifndef FLUX_ROCM_H
+#define FLUX_ROCM_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ========================================================================
+ * Initialization / Cleanup
+ * ======================================================================== */
+
+/*
+ * Initialize ROCm acceleration.
+ * Returns 1 on success, 0 if ROCm is not available.
+ * Safe to call multiple times.
+ */
+int flux_rocm_init(void);
+
+/*
+ * Check if ROCm acceleration is available and initialized.
+ */
+int flux_rocm_available(void);
+
+/*
+ * Cleanup ROCm resources.
+ */
+void flux_rocm_cleanup(void);
+
+/*
+ * Reset GPU state (clear caches/pools).
+ * Call between independent inference phases.
+ */
+void flux_rocm_reset(void);
+
+/*
+ * Synchronize all pending GPU operations.
+ */
+void flux_rocm_sync(void);
+
+/*
+ * Get GPU memory usage info (for debugging).
+ */
+size_t flux_rocm_memory_used(void);
+
+/* ========================================================================
+ * GPU Tensor API
+ * 
+ * Unlike Apple Silicon's unified memory, discrete GPUs require explicit
+ * memory management. These tensors live on GPU and are transferred
+ * explicitly when needed.
+ * ======================================================================== */
+
+/*
+ * Opaque handle to a GPU-resident tensor.
+ */
+typedef struct flux_rocm_tensor *flux_rocm_tensor_t;
+
+/*
+ * Create a GPU tensor and copy data from CPU.
+ * Returns NULL on failure.
+ */
+flux_rocm_tensor_t flux_rocm_tensor_create(const float *data, size_t num_elements);
+
+/*
+ * Create an uninitialized GPU tensor (for output buffers).
+ */
+flux_rocm_tensor_t flux_rocm_tensor_alloc(size_t num_elements);
+
+/*
+ * Create a persistent GPU tensor (won't return to pool on free).
+ */
+flux_rocm_tensor_t flux_rocm_tensor_alloc_persistent(size_t num_elements);
+
+/*
+ * Mark tensor as persistent.
+ */
+void flux_rocm_tensor_set_persistent(flux_rocm_tensor_t tensor, int persistent);
+
+/*
+ * Copy tensor data back to CPU.
+ * Blocks until GPU operations complete.
+ */
+void flux_rocm_tensor_read(flux_rocm_tensor_t tensor, float *out, size_t num_elements);
+
+/*
+ * Copy data from CPU to tensor.
+ */
+void flux_rocm_tensor_write(flux_rocm_tensor_t tensor, const float *data, size_t num_elements);
+
+/*
+ * Release a GPU tensor (returns to pool if not persistent).
+ */
+void flux_rocm_tensor_free(flux_rocm_tensor_t tensor);
+
+/*
+ * Get tensor element count.
+ */
+size_t flux_rocm_tensor_size(flux_rocm_tensor_t tensor);
+
+/*
+ * Check if tensor is bf16 format.
+ */
+int flux_rocm_tensor_is_bf16(flux_rocm_tensor_t tensor);
+
+/*
+ * Allocate bf16 tensor (half the memory of f32).
+ */
+flux_rocm_tensor_t flux_rocm_tensor_alloc_bf16(size_t num_elements);
+
+/*
+ * Get raw GPU pointer (for passing to BLAS/kernels).
+ * WARNING: Pointer is only valid while tensor exists.
+ */
+void *flux_rocm_tensor_gpu_ptr(flux_rocm_tensor_t tensor);
+
+/* ========================================================================
+ * BLAS Operations (via hipBLAS/rocBLAS)
+ * ======================================================================== */
+
+/*
+ * GPU matrix multiplication.
+ * C[M,N] = alpha * A[M,K] @ B[K,N] + beta * C[M,N]
+ *
+ * Data must already be on GPU (use tensor API).
+ */
+void flux_rocm_sgemm(int transpose_a, int transpose_b,
+                     int M, int N, int K,
+                     float alpha,
+                     const float *A, int lda,
+                     const float *B, int ldb,
+                     float beta,
+                     float *C, int ldc);
+
+/*
+ * GPU matrix multiplication with bf16 weights.
+ * A is f32, B is bf16, C is f32.
+ */
+void flux_rocm_sgemm_bf16(int transpose_a, int transpose_b,
+                          int M, int N, int K,
+                          float alpha,
+                          const float *A, int lda,
+                          const uint16_t *B_bf16, int ldb,
+                          float beta,
+                          float *C, int ldc);
+
+/*
+ * Batched GPU matrix multiplication.
+ */
+void flux_rocm_sgemm_batch(int transpose_a, int transpose_b,
+                           int M, int N, int K,
+                           float alpha,
+                           const float *A, int lda, int stride_a,
+                           const float *B, int ldb, int stride_b,
+                           float beta,
+                           float *C, int ldc, int stride_c,
+                           int batch_count);
+
+/* ========================================================================
+ * Linear Layers (GEMM wrappers for neural network use)
+ * ======================================================================== */
+
+/*
+ * Linear layer: out = x @ W^T
+ * x: [seq_len, in_dim]
+ * W: [out_dim, in_dim]
+ * Returns new GPU tensor with result.
+ */
+flux_rocm_tensor_t flux_rocm_linear(flux_rocm_tensor_t x,
+                                    const float *W,
+                                    int seq_len, int in_dim, int out_dim);
+
+/*
+ * Linear layer with bf16 weights.
+ */
+flux_rocm_tensor_t flux_rocm_linear_bf16(flux_rocm_tensor_t x,
+                                         const uint16_t *W_bf16,
+                                         int seq_len, int in_dim, int out_dim);
+
+/* ========================================================================
+ * Element-wise Operations (Custom HIP Kernels)
+ * ======================================================================== */
+
+/*
+ * RMSNorm: out = x * rsqrt(mean(x^2) + eps) * weight
+ * x: [seq_len, hidden], weight: [hidden]
+ */
+void flux_rocm_rms_norm(float *out, const float *x, const float *weight,
+                        int seq_len, int hidden, float eps);
+
+/*
+ * QK RMSNorm (in-place on Q and K).
+ * q, k: [seq, heads*head_dim]
+ * q_weight, k_weight: [head_dim]
+ */
+void flux_rocm_qk_rms_norm(float *q, float *k,
+                           const float *q_weight, const float *k_weight,
+                           int seq, int heads, int head_dim, float eps);
+
+/*
+ * AdaLN: out = (1 + scale) * layernorm(x) + shift
+ * x: [seq_len, hidden], shift/scale: [hidden]
+ */
+void flux_rocm_adaln_norm(float *out, const float *x,
+                          const float *shift, const float *scale,
+                          int seq_len, int hidden, float eps);
+
+/*
+ * SiLU activation (in-place): x = x * sigmoid(x)
+ */
+void flux_rocm_silu(float *x, int n);
+
+/*
+ * SiLU with multiply (SwiGLU, in-place): gate = silu(gate) * up
+ */
+void flux_rocm_silu_mul(float *gate, const float *up, int n);
+
+/*
+ * Softmax (row-wise, in-place).
+ * x: [rows, cols]
+ */
+void flux_rocm_softmax(float *x, int rows, int cols);
+
+/*
+ * Gated add: out += gate * proj
+ */
+void flux_rocm_gated_add(float *out, const float *gate,
+                         const float *proj, int seq, int hidden);
+
+/* ========================================================================
+ * RoPE (Rotary Position Embeddings)
+ * ======================================================================== */
+
+/*
+ * 2D RoPE (in-place).
+ * x: [seq, heads*head_dim]
+ * cos_freq, sin_freq: [seq, axis_dim]
+ */
+void flux_rocm_rope_2d(float *x, const float *cos_freq, const float *sin_freq,
+                       int seq, int heads, int head_dim, int axis_dim);
+
+/*
+ * Unified RoPE for text+image.
+ * Different frequencies for text (0 to img_offset) and image portions.
+ */
+void flux_rocm_rope_unified(float *q, float *k,
+                            const float *txt_cos, const float *txt_sin,
+                            const float *img_cos, const float *img_sin,
+                            int seq, int img_offset, int heads, int head_dim, int axis_dim);
+
+/* ========================================================================
+ * Attention
+ * ======================================================================== */
+
+/*
+ * Fused attention (non-causal, for transformer).
+ * Works on [seq, hidden] layout.
+ * Returns 1 on success, 0 on failure.
+ */
+int flux_rocm_attention_fused(float *out,
+                              const float *Q, const float *K, const float *V,
+                              int seq_q, int seq_k, int num_heads, int head_dim,
+                              float scale);
+
+/*
+ * Causal attention (for text encoder).
+ * Supports GQA (num_q_heads > num_kv_heads).
+ * Returns 1 on success, 0 on failure.
+ */
+int flux_rocm_causal_attention(float *out,
+                               const float *Q, const float *K, const float *V,
+                               const int *attention_mask,
+                               int seq, int num_q_heads, int num_kv_heads,
+                               int head_dim, float scale);
+
+/* ========================================================================
+ * Tensor Operations (GPU tensor API)
+ * ======================================================================== */
+
+/* AdaLN on GPU tensors */
+void flux_rocm_gpu_adaln_norm(flux_rocm_tensor_t out, flux_rocm_tensor_t x,
+                              const float *shift, const float *scale,
+                              int seq, int hidden, float eps);
+
+/* QK RMSNorm on GPU tensors (in-place) */
+void flux_rocm_gpu_qk_rms_norm(flux_rocm_tensor_t q, flux_rocm_tensor_t k,
+                               const float *q_weight, const float *k_weight,
+                               int seq, int heads, int head_dim, float eps);
+
+/* RoPE unified on GPU tensors */
+void flux_rocm_gpu_rope_unified(flux_rocm_tensor_t q, flux_rocm_tensor_t k,
+                                const float *txt_cos, const float *txt_sin,
+                                const float *img_cos, const float *img_sin,
+                                int seq, int img_offset, int heads, int head_dim, int axis_dim);
+
+/* SiLU multiply on GPU tensors */
+void flux_rocm_gpu_silu_mul(flux_rocm_tensor_t gate, flux_rocm_tensor_t up, int n);
+
+/* Gated add on GPU tensors */
+void flux_rocm_gpu_gated_add(flux_rocm_tensor_t out, const float *gate,
+                             flux_rocm_tensor_t proj, int seq, int hidden);
+
+/* Fused attention on GPU tensors */
+int flux_rocm_gpu_attention_fused(flux_rocm_tensor_t out,
+                                  flux_rocm_tensor_t Q, flux_rocm_tensor_t K, flux_rocm_tensor_t V,
+                                  int seq_q, int seq_k, int num_heads, int head_dim, float scale);
+
+/* Split fused QKV+MLP output */
+void flux_rocm_gpu_split_qkv_mlp(flux_rocm_tensor_t fused,
+                                 flux_rocm_tensor_t q, flux_rocm_tensor_t k, flux_rocm_tensor_t v,
+                                 flux_rocm_tensor_t gate, flux_rocm_tensor_t up,
+                                 int seq, int hidden, int mlp_hidden);
+
+/* Concatenate attention and MLP outputs */
+void flux_rocm_gpu_concat_attn_mlp(flux_rocm_tensor_t attn, flux_rocm_tensor_t mlp,
+                                   flux_rocm_tensor_t out, int seq, int hidden, int mlp_hidden);
+
+/* ========================================================================
+ * Batch/Chain API (for operation fusion)
+ * ======================================================================== */
+
+/*
+ * Begin batch mode - operations queued but not executed.
+ */
+void flux_rocm_batch_begin(void);
+
+/*
+ * End batch mode - execute all queued operations.
+ */
+void flux_rocm_batch_end(void);
+
+/*
+ * Check if in batch mode.
+ */
+int flux_rocm_in_batch(void);
+
+/*
+ * Begin operation chain (shared stream, minimal sync).
+ */
+void flux_rocm_chain_begin(void);
+
+/*
+ * End operation chain.
+ */
+void flux_rocm_chain_end(void);
+
+/*
+ * Check if in chain mode.
+ */
+int flux_rocm_in_chain(void);
+
+/* ========================================================================
+ * Utility
+ * ======================================================================== */
+
+/*
+ * Check if custom HIP kernels are available.
+ */
+int flux_rocm_kernels_available(void);
+
+/*
+ * Pre-warm bf16 conversion cache for weights.
+ */
+void flux_rocm_warmup_bf16(const uint16_t *bf16_weights, size_t num_elements);
+
+/*
+ * Check if bf16 pipeline is available.
+ */
+int flux_rocm_bf16_available(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FLUX_ROCM_H */

--- a/rocm/flux_rocm_compat.cpp
+++ b/rocm/flux_rocm_compat.cpp
@@ -1,0 +1,212 @@
+/*
+ * FLUX ROCm Compatibility Layer - Implementation
+ *
+ * CPU-pointer wrappers for ROCm operations.
+ * These handle the GPU memory management automatically.
+ */
+
+#include "flux_rocm_compat.h"
+#include "flux_rocm.h"
+#include <hip/hip_runtime.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unordered_map>
+#include <mutex>
+
+/* External functions from flux_rocm.cpp */
+extern hipStream_t get_stream();
+
+/* ========================================================================
+ * Activation Cache
+ * 
+ * For activations that we see repeatedly (same size), we can reuse buffers.
+ * This avoids malloc/free overhead for every operation.
+ * ======================================================================== */
+
+struct activation_cache {
+    void *d_A;
+    void *d_C;
+    size_t A_bytes;
+    size_t C_bytes;
+};
+
+static activation_cache g_act_cache = {nullptr, nullptr, 0, 0};
+static std::mutex g_act_mutex;
+
+static void* get_activation_buffer(size_t bytes, void **cache_ptr, size_t *cache_size) {
+    if (*cache_ptr && *cache_size >= bytes) {
+        return *cache_ptr;
+    }
+    
+    if (*cache_ptr) {
+        hipFree(*cache_ptr);
+    }
+    
+    void *ptr = nullptr;
+    if (hipMalloc(&ptr, bytes) != hipSuccess) {
+        fprintf(stderr, "ROCm compat: failed to allocate %zu bytes\n", bytes);
+        return nullptr;
+    }
+    
+    *cache_ptr = ptr;
+    *cache_size = bytes;
+    return ptr;
+}
+
+/* ========================================================================
+ * Weight Cache (reuse from flux_rocm.cpp via extern)
+ * ======================================================================== */
+
+/* Forward declaration - implemented in flux_rocm.cpp */
+extern void* get_cached_weight(const void *cpu_ptr, size_t bytes);
+
+/* ========================================================================
+ * CPU-Pointer SGEMM
+ *
+ * C[M,N] = alpha * A[M,K] @ B[K,N] + beta * C[M,N]
+ *
+ * Strategy:
+ * - A (activations): Upload, compute, may be reused
+ * - B (weights): Use weight cache (uploaded once)
+ * - C (output): Allocate, compute, download
+ * ======================================================================== */
+
+extern "C" void flux_rocm_sgemm_cpu(int transpose_a, int transpose_b,
+                                     int M, int N, int K,
+                                     float alpha,
+                                     const float *A, int lda,
+                                     const float *B, int ldb,
+                                     float beta,
+                                     float *C, int ldc) {
+    if (!flux_rocm_available()) return;
+    
+    hipStream_t stream = get_stream();
+    
+    /* Calculate sizes */
+    size_t A_rows = transpose_a ? K : M;
+    size_t A_cols = transpose_a ? M : K;
+    size_t B_rows = transpose_b ? N : K;
+    size_t B_cols = transpose_b ? K : N;
+    
+    size_t A_bytes = A_rows * A_cols * sizeof(float);
+    size_t B_bytes = B_rows * B_cols * sizeof(float);
+    size_t C_bytes = M * N * sizeof(float);
+    
+    /* Get GPU buffers */
+    std::lock_guard<std::mutex> lock(g_act_mutex);
+    
+    void *d_A = get_activation_buffer(A_bytes, &g_act_cache.d_A, &g_act_cache.A_bytes);
+    void *d_C = get_activation_buffer(C_bytes, &g_act_cache.d_C, &g_act_cache.C_bytes);
+    
+    if (!d_A || !d_C) return;
+    
+    /* B is typically weights - use cache */
+    void *d_B = get_cached_weight(B, B_bytes);
+    if (!d_B) return;
+    
+    /* Upload A */
+    hipMemcpyAsync(d_A, A, A_bytes, hipMemcpyHostToDevice, stream);
+    
+    /* Upload C if beta != 0 */
+    if (beta != 0.0f) {
+        hipMemcpyAsync(d_C, C, C_bytes, hipMemcpyHostToDevice, stream);
+    }
+    
+    /* Run SGEMM on GPU */
+    flux_rocm_sgemm(transpose_a, transpose_b,
+                    M, N, K,
+                    alpha,
+                    (float*)d_A, lda,
+                    (float*)d_B, ldb,
+                    beta,
+                    (float*)d_C, ldc);
+    
+    /* Download C */
+    hipMemcpyAsync(C, d_C, C_bytes, hipMemcpyDeviceToHost, stream);
+    hipStreamSynchronize(stream);
+}
+
+/* ========================================================================
+ * CPU-Pointer RMSNorm
+ * ======================================================================== */
+
+extern "C" void flux_rocm_rms_norm_cpu(float *out, const float *x, const float *weight,
+                                        int seq_len, int hidden, float eps) {
+    if (!flux_rocm_available()) return;
+    
+    hipStream_t stream = get_stream();
+    
+    size_t data_bytes = seq_len * hidden * sizeof(float);
+    size_t weight_bytes = hidden * sizeof(float);
+    
+    /* Allocate GPU memory */
+    void *d_x = nullptr, *d_out = nullptr;
+    hipMalloc(&d_x, data_bytes);
+    hipMalloc(&d_out, data_bytes);
+    
+    /* Weight uses cache */
+    void *d_weight = get_cached_weight(weight, weight_bytes);
+    
+    if (!d_x || !d_out || !d_weight) {
+        if (d_x) hipFree(d_x);
+        if (d_out) hipFree(d_out);
+        return;
+    }
+    
+    /* Upload */
+    hipMemcpyAsync(d_x, x, data_bytes, hipMemcpyHostToDevice, stream);
+    
+    /* Compute */
+    flux_rocm_rms_norm((float*)d_out, (float*)d_x, (float*)d_weight, seq_len, hidden, eps);
+    
+    /* Download */
+    hipMemcpyAsync(out, d_out, data_bytes, hipMemcpyDeviceToHost, stream);
+    hipStreamSynchronize(stream);
+    
+    hipFree(d_x);
+    hipFree(d_out);
+}
+
+/* ========================================================================
+ * CPU-Pointer SiLU
+ * ======================================================================== */
+
+extern "C" void flux_rocm_silu_cpu(float *x, int n) {
+    if (!flux_rocm_available()) return;
+    
+    hipStream_t stream = get_stream();
+    size_t bytes = n * sizeof(float);
+    
+    void *d_x = nullptr;
+    hipMalloc(&d_x, bytes);
+    if (!d_x) return;
+    
+    hipMemcpyAsync(d_x, x, bytes, hipMemcpyHostToDevice, stream);
+    flux_rocm_silu((float*)d_x, n);
+    hipMemcpyAsync(x, d_x, bytes, hipMemcpyDeviceToHost, stream);
+    hipStreamSynchronize(stream);
+    
+    hipFree(d_x);
+}
+
+/* ========================================================================
+ * CPU-Pointer Softmax
+ * ======================================================================== */
+
+extern "C" void flux_rocm_softmax_cpu(float *x, int rows, int cols) {
+    if (!flux_rocm_available()) return;
+    
+    hipStream_t stream = get_stream();
+    size_t bytes = rows * cols * sizeof(float);
+    
+    void *d_x = nullptr;
+    hipMalloc(&d_x, bytes);
+    if (!d_x) return;
+    
+    hipMemcpyAsync(d_x, x, bytes, hipMemcpyHostToDevice, stream);
+    flux_rocm_softmax((float*)d_x, rows, cols);
+    hipMemcpyAsync(x, d_x, bytes, hipMemcpyDeviceToHost, stream);
+    hipStreamSynchronize(stream);
+    
+    hipFree(d_x);
+}

--- a/rocm/flux_rocm_compat.h
+++ b/rocm/flux_rocm_compat.h
@@ -1,0 +1,71 @@
+/*
+ * FLUX ROCm Compatibility Layer
+ *
+ * Drop-in wrappers that match flux_metal.h function signatures.
+ * This allows flux_kernels.c to use ROCm with minimal changes.
+ */
+
+#ifndef FLUX_ROCM_COMPAT_H
+#define FLUX_ROCM_COMPAT_H
+
+#include "flux_rocm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Alias init/available/cleanup to match Metal naming */
+#define flux_metal_init flux_rocm_init
+#define flux_metal_available flux_rocm_available
+#define flux_metal_cleanup flux_rocm_cleanup
+#define flux_metal_sync flux_rocm_sync
+
+/* Alias SGEMM operations */
+#define flux_metal_sgemm flux_rocm_sgemm
+#define flux_metal_sgemm_bf16 flux_rocm_sgemm_bf16
+#define flux_metal_sgemm_batch flux_rocm_sgemm_batch
+
+/* Alias kernel operations */
+#define flux_metal_rms_norm flux_rocm_rms_norm
+#define flux_metal_silu flux_rocm_silu
+#define flux_metal_softmax flux_rocm_softmax
+#define flux_metal_shaders_available flux_rocm_kernels_available
+
+/* Batch/chain operations */
+#define flux_metal_begin_batch flux_rocm_batch_begin
+#define flux_metal_end_batch flux_rocm_batch_end
+
+/*
+ * CPU-pointer wrapper for SGEMM.
+ * Handles upload to GPU, compute, download automatically.
+ * Uses weight caching for B matrix (typically the model weights).
+ */
+void flux_rocm_sgemm_cpu(int transpose_a, int transpose_b,
+                         int M, int N, int K,
+                         float alpha,
+                         const float *A, int lda,
+                         const float *B, int ldb,
+                         float beta,
+                         float *C, int ldc);
+
+/*
+ * CPU-pointer wrapper for RMSNorm.
+ */
+void flux_rocm_rms_norm_cpu(float *out, const float *x, const float *weight,
+                            int seq_len, int hidden, float eps);
+
+/*
+ * CPU-pointer wrapper for SiLU.
+ */
+void flux_rocm_silu_cpu(float *x, int n);
+
+/*
+ * CPU-pointer wrapper for Softmax.
+ */
+void flux_rocm_softmax_cpu(float *x, int rows, int cols);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* FLUX_ROCM_COMPAT_H */

--- a/rocm/flux_rocm_kernels.hip
+++ b/rocm/flux_rocm_kernels.hip
@@ -315,11 +315,20 @@ __global__ void kernel_gated_add(float *out, const float *gate,
  *   x_new[2i+1] = x[2i] * sin + x[2i+1] * cos
  * ======================================================================== */
 
+/* RoPE 2D kernel
+ * x: [seq, heads * head_dim]
+ * cos_freq, sin_freq: [seq, head_dim] - frequency tables per position
+ *
+ * Applies rotation to ALL head_dim elements (128), not just axis_dim (32).
+ * Each pair (d, d+1) is rotated by (cos[d], sin[d]).
+ */
 __global__ void kernel_rope_2d(float *x, const float *cos_freq, const float *sin_freq,
                                int seq, int heads, int head_dim, int axis_dim) {
+    (void)axis_dim;  /* Not used - we always process all head_dim elements */
+    
     /* Each thread handles one rotation pair */
     int pair_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int pairs_per_head = axis_dim / 2;
+    int pairs_per_head = head_dim / 2;  /* 64 pairs for head_dim=128 */
     int total_pairs = seq * heads * pairs_per_head;
     
     if (pair_idx >= total_pairs) return;
@@ -329,28 +338,38 @@ __global__ void kernel_rope_2d(float *x, const float *cos_freq, const float *sin
     int head = tmp % heads;
     int s = tmp / heads;
     
-    /* Position in x tensor */
+    /* Position in x tensor: [s, head, d] */
     int x_base = s * (heads * head_dim) + head * head_dim + p * 2;
     
-    /* Position in frequency tensor */
-    int freq_idx = s * axis_dim + p * 2;
+    /* Position in frequency tensor: [s, d] where d is element index */
+    int freq_idx = s * head_dim + p * 2;
     
     float x0 = x[x_base];
     float x1 = x[x_base + 1];
-    float cos_val = cos_freq[freq_idx / 2];  /* cos is stored per pair */
-    float sin_val = sin_freq[freq_idx / 2];
+    float cos_val = cos_freq[freq_idx];  /* cos[d] == cos[d+1] due to repeat_interleave */
+    float sin_val = sin_freq[freq_idx];
     
     x[x_base]     = x0 * cos_val - x1 * sin_val;
     x[x_base + 1] = x0 * sin_val + x1 * cos_val;
 }
 
 /* Unified RoPE for text + image (different frequencies) */
+/* Unified RoPE for text + image (different frequencies)
+ * q, k: [seq, heads * head_dim]
+ * cos/sin tables: [local_seq, head_dim] where local_seq is txt_seq or img_seq
+ *
+ * The CPU code applies RoPE to ALL head_dim elements (128), not just axis_dim (32).
+ * For text positions: axes 0-2 have cos=1, sin=0 (identity), axis 3 has rotation
+ * For image positions: all 4 axes have rotations based on 2D position
+ */
 __global__ void kernel_rope_unified(float *q, float *k,
                                     const float *txt_cos, const float *txt_sin,
                                     const float *img_cos, const float *img_sin,
                                     int seq, int img_offset, int heads, int head_dim, int axis_dim) {
+    (void)axis_dim;  /* Not used - we always process all head_dim elements */
+    
     int pair_idx = blockIdx.x * blockDim.x + threadIdx.x;
-    int pairs_per_head = axis_dim / 2;
+    int pairs_per_head = head_dim / 2;  /* 64 pairs for head_dim=128 */
     int total_pairs = seq * heads * pairs_per_head;
     
     if (pair_idx >= total_pairs) return;
@@ -367,8 +386,9 @@ __global__ void kernel_rope_unified(float *q, float *k,
     const float *cos_tbl = is_img ? img_cos : txt_cos;
     const float *sin_tbl = is_img ? img_sin : txt_sin;
     
-    int freq_idx = local_s * pairs_per_head + p;
-    float cos_val = cos_tbl[freq_idx];
+    /* Frequency index: [local_s, d] where d is the pair's element index */
+    int freq_idx = local_s * head_dim + p * 2;
+    float cos_val = cos_tbl[freq_idx];  /* cos[d] == cos[d+1] due to repeat_interleave */
     float sin_val = sin_tbl[freq_idx];
     
     /* Apply to Q */
@@ -481,7 +501,8 @@ void flux_rocm_kernel_gated_add(float *out, const float *gate, const float *proj
 
 void flux_rocm_kernel_rope_2d(float *x, const float *cos_freq, const float *sin_freq,
                               int seq, int heads, int head_dim, int axis_dim, hipStream_t stream) {
-    int pairs_per_head = axis_dim / 2;
+    (void)axis_dim;  /* Not used - we process all head_dim elements */
+    int pairs_per_head = head_dim / 2;  /* 64 pairs for head_dim=128 */
     int total_pairs = seq * heads * pairs_per_head;
     int threads = 256;
     int blocks = (total_pairs + threads - 1) / threads;
@@ -493,7 +514,8 @@ void flux_rocm_kernel_rope_unified(float *q, float *k,
                                    const float *img_cos, const float *img_sin,
                                    int seq, int img_offset, int heads, int head_dim, int axis_dim,
                                    hipStream_t stream) {
-    int pairs_per_head = axis_dim / 2;
+    (void)axis_dim;  /* Not used - we process all head_dim elements */
+    int pairs_per_head = head_dim / 2;  /* 64 pairs for head_dim=128 */
     int total_pairs = seq * heads * pairs_per_head;
     int threads = 256;
     int blocks = (total_pairs + threads - 1) / threads;

--- a/rocm/flux_rocm_kernels.hip
+++ b/rocm/flux_rocm_kernels.hip
@@ -1,0 +1,522 @@
+/*
+ * FLUX ROCm Custom Kernels
+ *
+ * HIP kernels for operations that aren't covered by hipBLAS.
+ * These are the building blocks for transformer inference.
+ */
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_fp16.h>
+#include <math.h>
+#include <float.h>
+
+/* ========================================================================
+ * Helper Macros
+ * ======================================================================== */
+
+/* RDNA uses 32-wide wavefronts (not 64 like GCN/CDNA) */
+#define WARP_SIZE 32
+#define MAX_THREADS 256
+#define MAX_WARPS (MAX_THREADS / WARP_SIZE)
+
+/* Warp-level reduction */
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+        val += __shfl_down(val, offset);
+    }
+    return val;
+}
+
+__device__ __forceinline__ float warp_reduce_max(float val) {
+    for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2) {
+        val = fmaxf(val, __shfl_down(val, offset));
+    }
+    return val;
+}
+
+/* Block-level reduction using shared memory */
+__device__ float block_reduce_sum(float val) {
+    __shared__ float shared[MAX_WARPS];
+    
+    int lane = threadIdx.x % WARP_SIZE;
+    int wid = threadIdx.x / WARP_SIZE;
+    int num_warps = (blockDim.x + WARP_SIZE - 1) / WARP_SIZE;
+    
+    /* Warp-level reduction */
+    val = warp_reduce_sum(val);
+    
+    /* Store warp results */
+    if (lane == 0) shared[wid] = val;
+    __syncthreads();
+    
+    /* Final reduction in first warp */
+    if (threadIdx.x < num_warps) {
+        val = shared[threadIdx.x];
+    } else {
+        val = 0.0f;
+    }
+    
+    if (wid == 0) {
+        val = warp_reduce_sum(val);
+    }
+    
+    return val;
+}
+
+__device__ float block_reduce_max(float val) {
+    __shared__ float shared[MAX_WARPS];
+    
+    int lane = threadIdx.x % WARP_SIZE;
+    int wid = threadIdx.x / WARP_SIZE;
+    int num_warps = (blockDim.x + WARP_SIZE - 1) / WARP_SIZE;
+    
+    val = warp_reduce_max(val);
+    
+    if (lane == 0) shared[wid] = val;
+    __syncthreads();
+    
+    if (threadIdx.x < num_warps) {
+        val = shared[threadIdx.x];
+    } else {
+        val = -FLT_MAX;
+    }
+    
+    if (wid == 0) {
+        val = warp_reduce_max(val);
+    }
+    
+    return val;
+}
+
+/* ========================================================================
+ * SiLU Activation: x * sigmoid(x)
+ * ======================================================================== */
+
+__global__ void kernel_silu(float *x, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        float val = x[i];
+        x[i] = val / (1.0f + expf(-val));
+    }
+}
+
+__global__ void kernel_silu_mul(float *gate, const float *up, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) {
+        float g = gate[i];
+        float u = up[i];
+        gate[i] = (g / (1.0f + expf(-g))) * u;
+    }
+}
+
+/* ========================================================================
+ * RMSNorm: out = x * rsqrt(mean(x^2) + eps) * weight
+ * ======================================================================== */
+
+__global__ void kernel_rms_norm(float *out, const float *x, const float *weight,
+                                int seq_len, int hidden, float eps) {
+    /* One block per sequence position */
+    int seq_idx = blockIdx.x;
+    if (seq_idx >= seq_len) return;
+    
+    const float *x_row = x + seq_idx * hidden;
+    float *out_row = out + seq_idx * hidden;
+    
+    /* Compute sum of squares */
+    float sum_sq = 0.0f;
+    for (int i = threadIdx.x; i < hidden; i += blockDim.x) {
+        float val = x_row[i];
+        sum_sq += val * val;
+    }
+    sum_sq = block_reduce_sum(sum_sq);
+    
+    /* Broadcast RMS to all threads */
+    __shared__ float s_rms_inv;
+    if (threadIdx.x == 0) {
+        s_rms_inv = rsqrtf(sum_sq / hidden + eps);
+    }
+    __syncthreads();
+    
+    /* Apply normalization and weight */
+    for (int i = threadIdx.x; i < hidden; i += blockDim.x) {
+        out_row[i] = x_row[i] * s_rms_inv * weight[i];
+    }
+}
+
+/* ========================================================================
+ * QK RMSNorm: Per-head normalization for Q and K
+ * q, k: [seq, heads * head_dim]
+ * weight: [head_dim]
+ * ======================================================================== */
+
+__global__ void kernel_qk_rms_norm(float *q, float *k,
+                                   const float *q_weight, const float *k_weight,
+                                   int seq, int heads, int head_dim, float eps) {
+    /* One block per (seq_idx, head_idx) */
+    int idx = blockIdx.x;
+    int total = seq * heads;
+    if (idx >= total) return;
+    
+    int seq_idx = idx / heads;
+    int head_idx = idx % heads;
+    
+    int offset = seq_idx * (heads * head_dim) + head_idx * head_dim;
+    float *q_head = q + offset;
+    float *k_head = k + offset;
+    
+    /* RMSNorm for Q */
+    float sum_sq_q = 0.0f;
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+        float val = q_head[i];
+        sum_sq_q += val * val;
+    }
+    sum_sq_q = block_reduce_sum(sum_sq_q);
+    
+    __shared__ float s_rms_inv_q;
+    if (threadIdx.x == 0) {
+        s_rms_inv_q = rsqrtf(sum_sq_q / head_dim + eps);
+    }
+    __syncthreads();
+    
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+        q_head[i] = q_head[i] * s_rms_inv_q * q_weight[i];
+    }
+    __syncthreads();
+    
+    /* RMSNorm for K */
+    float sum_sq_k = 0.0f;
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+        float val = k_head[i];
+        sum_sq_k += val * val;
+    }
+    sum_sq_k = block_reduce_sum(sum_sq_k);
+    
+    __shared__ float s_rms_inv_k;
+    if (threadIdx.x == 0) {
+        s_rms_inv_k = rsqrtf(sum_sq_k / head_dim + eps);
+    }
+    __syncthreads();
+    
+    for (int i = threadIdx.x; i < head_dim; i += blockDim.x) {
+        k_head[i] = k_head[i] * s_rms_inv_k * k_weight[i];
+    }
+}
+
+/* ========================================================================
+ * AdaLN: out = (1 + scale) * layernorm(x) + shift
+ * ======================================================================== */
+
+__global__ void kernel_adaln_norm(float *out, const float *x,
+                                  const float *shift, const float *scale,
+                                  int seq_len, int hidden, float eps) {
+    int seq_idx = blockIdx.x;
+    if (seq_idx >= seq_len) return;
+    
+    const float *x_row = x + seq_idx * hidden;
+    float *out_row = out + seq_idx * hidden;
+    
+    /* Compute mean */
+    float sum = 0.0f;
+    for (int i = threadIdx.x; i < hidden; i += blockDim.x) {
+        sum += x_row[i];
+    }
+    sum = block_reduce_sum(sum);
+    
+    __shared__ float s_mean;
+    if (threadIdx.x == 0) {
+        s_mean = sum / hidden;
+    }
+    __syncthreads();
+    
+    /* Compute variance */
+    float var_sum = 0.0f;
+    for (int i = threadIdx.x; i < hidden; i += blockDim.x) {
+        float diff = x_row[i] - s_mean;
+        var_sum += diff * diff;
+    }
+    var_sum = block_reduce_sum(var_sum);
+    
+    __shared__ float s_var_inv;
+    if (threadIdx.x == 0) {
+        s_var_inv = rsqrtf(var_sum / hidden + eps);
+    }
+    __syncthreads();
+    
+    /* Apply: out = (1 + scale) * norm(x) + shift */
+    for (int i = threadIdx.x; i < hidden; i += blockDim.x) {
+        float norm_val = (x_row[i] - s_mean) * s_var_inv;
+        out_row[i] = (1.0f + scale[i]) * norm_val + shift[i];
+    }
+}
+
+/* ========================================================================
+ * Softmax (row-wise)
+ * x: [rows, cols]
+ * ======================================================================== */
+
+__global__ void kernel_softmax(float *x, int rows, int cols) {
+    int row = blockIdx.x;
+    if (row >= rows) return;
+    
+    float *row_ptr = x + row * cols;
+    
+    /* Find max for numerical stability */
+    float max_val = -FLT_MAX;
+    for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+        max_val = fmaxf(max_val, row_ptr[i]);
+    }
+    max_val = block_reduce_max(max_val);
+    
+    __shared__ float s_max;
+    if (threadIdx.x == 0) s_max = max_val;
+    __syncthreads();
+    
+    /* Compute exp(x - max) and sum */
+    float sum = 0.0f;
+    for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+        float val = expf(row_ptr[i] - s_max);
+        row_ptr[i] = val;
+        sum += val;
+    }
+    sum = block_reduce_sum(sum);
+    
+    __shared__ float s_sum_inv;
+    if (threadIdx.x == 0) s_sum_inv = 1.0f / sum;
+    __syncthreads();
+    
+    /* Normalize */
+    for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+        row_ptr[i] *= s_sum_inv;
+    }
+}
+
+/* ========================================================================
+ * Gated Add: out += gate * proj
+ * ======================================================================== */
+
+__global__ void kernel_gated_add(float *out, const float *gate,
+                                 const float *proj, int seq, int hidden) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * hidden;
+    if (idx >= total) return;
+    
+    int h = idx % hidden;
+    out[idx] += gate[h] * proj[idx];
+}
+
+/* ========================================================================
+ * RoPE (Rotary Position Embeddings)
+ * 
+ * x: [seq, heads * head_dim]
+ * cos_freq, sin_freq: [seq, axis_dim] - precomputed frequencies
+ * 
+ * RoPE rotates pairs of adjacent elements:
+ *   x_new[2i]   = x[2i] * cos - x[2i+1] * sin
+ *   x_new[2i+1] = x[2i] * sin + x[2i+1] * cos
+ * ======================================================================== */
+
+__global__ void kernel_rope_2d(float *x, const float *cos_freq, const float *sin_freq,
+                               int seq, int heads, int head_dim, int axis_dim) {
+    /* Each thread handles one rotation pair */
+    int pair_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int pairs_per_head = axis_dim / 2;
+    int total_pairs = seq * heads * pairs_per_head;
+    
+    if (pair_idx >= total_pairs) return;
+    
+    int p = pair_idx % pairs_per_head;
+    int tmp = pair_idx / pairs_per_head;
+    int head = tmp % heads;
+    int s = tmp / heads;
+    
+    /* Position in x tensor */
+    int x_base = s * (heads * head_dim) + head * head_dim + p * 2;
+    
+    /* Position in frequency tensor */
+    int freq_idx = s * axis_dim + p * 2;
+    
+    float x0 = x[x_base];
+    float x1 = x[x_base + 1];
+    float cos_val = cos_freq[freq_idx / 2];  /* cos is stored per pair */
+    float sin_val = sin_freq[freq_idx / 2];
+    
+    x[x_base]     = x0 * cos_val - x1 * sin_val;
+    x[x_base + 1] = x0 * sin_val + x1 * cos_val;
+}
+
+/* Unified RoPE for text + image (different frequencies) */
+__global__ void kernel_rope_unified(float *q, float *k,
+                                    const float *txt_cos, const float *txt_sin,
+                                    const float *img_cos, const float *img_sin,
+                                    int seq, int img_offset, int heads, int head_dim, int axis_dim) {
+    int pair_idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int pairs_per_head = axis_dim / 2;
+    int total_pairs = seq * heads * pairs_per_head;
+    
+    if (pair_idx >= total_pairs) return;
+    
+    int p = pair_idx % pairs_per_head;
+    int tmp = pair_idx / pairs_per_head;
+    int head = tmp % heads;
+    int s = tmp / heads;
+    
+    /* Select frequency table based on position */
+    int is_img = (s >= img_offset);
+    int local_s = is_img ? (s - img_offset) : s;
+    
+    const float *cos_tbl = is_img ? img_cos : txt_cos;
+    const float *sin_tbl = is_img ? img_sin : txt_sin;
+    
+    int freq_idx = local_s * pairs_per_head + p;
+    float cos_val = cos_tbl[freq_idx];
+    float sin_val = sin_tbl[freq_idx];
+    
+    /* Apply to Q */
+    int q_base = s * (heads * head_dim) + head * head_dim + p * 2;
+    float q0 = q[q_base];
+    float q1 = q[q_base + 1];
+    q[q_base]     = q0 * cos_val - q1 * sin_val;
+    q[q_base + 1] = q0 * sin_val + q1 * cos_val;
+    
+    /* Apply to K */
+    int k_base = q_base;  /* Same layout */
+    float k0 = k[k_base];
+    float k1 = k[k_base + 1];
+    k[k_base]     = k0 * cos_val - k1 * sin_val;
+    k[k_base + 1] = k0 * sin_val + k1 * cos_val;
+}
+
+/* ========================================================================
+ * Transpose Kernels for Attention
+ * ======================================================================== */
+
+/* Transpose from [seq, heads*head_dim] to [heads, seq, head_dim] */
+__global__ void kernel_transpose_to_heads(float *out, const float *in,
+                                          int seq, int heads, int head_dim) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * heads * head_dim;
+    if (idx >= total) return;
+    
+    int d = idx % head_dim;
+    int tmp = idx / head_dim;
+    int s = tmp % seq;
+    int h = tmp / seq;
+    
+    /* out[h, s, d] = in[s, h*head_dim + d] */
+    int in_idx = s * (heads * head_dim) + h * head_dim + d;
+    out[idx] = in[in_idx];
+}
+
+/* Transpose from [heads, seq, head_dim] to [seq, heads*head_dim] */
+__global__ void kernel_transpose_from_heads(float *out, const float *in,
+                                            int seq, int heads, int head_dim) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = seq * heads * head_dim;
+    if (idx >= total) return;
+    
+    int d = idx % head_dim;
+    int tmp = idx / head_dim;
+    int s = tmp % seq;
+    int h = tmp / seq;
+    
+    /* out[s, h*head_dim + d] = in[h, s, d] */
+    int out_idx = s * (heads * head_dim) + h * head_dim + d;
+    int in_idx = h * (seq * head_dim) + s * head_dim + d;
+    out[out_idx] = in[in_idx];
+}
+
+/* ========================================================================
+ * C Interface Wrappers
+ * ======================================================================== */
+
+extern "C" {
+
+static hipStream_t get_stream();  /* Defined in flux_rocm.cpp */
+
+void flux_rocm_kernel_silu(float *x, int n, hipStream_t stream) {
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    kernel_silu<<<blocks, threads, 0, stream>>>(x, n);
+}
+
+void flux_rocm_kernel_silu_mul(float *gate, const float *up, int n, hipStream_t stream) {
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    kernel_silu_mul<<<blocks, threads, 0, stream>>>(gate, up, n);
+}
+
+void flux_rocm_kernel_rms_norm(float *out, const float *x, const float *weight,
+                               int seq_len, int hidden, float eps, hipStream_t stream) {
+    int threads = min(256, hidden);
+    kernel_rms_norm<<<seq_len, threads, 0, stream>>>(out, x, weight, seq_len, hidden, eps);
+}
+
+void flux_rocm_kernel_qk_rms_norm(float *q, float *k,
+                                  const float *q_weight, const float *k_weight,
+                                  int seq, int heads, int head_dim, float eps, hipStream_t stream) {
+    int threads = min(256, head_dim);
+    int blocks = seq * heads;
+    kernel_qk_rms_norm<<<blocks, threads, 0, stream>>>(q, k, q_weight, k_weight, seq, heads, head_dim, eps);
+}
+
+void flux_rocm_kernel_adaln_norm(float *out, const float *x,
+                                 const float *shift, const float *scale,
+                                 int seq_len, int hidden, float eps, hipStream_t stream) {
+    int threads = min(256, hidden);
+    kernel_adaln_norm<<<seq_len, threads, 0, stream>>>(out, x, shift, scale, seq_len, hidden, eps);
+}
+
+void flux_rocm_kernel_softmax(float *x, int rows, int cols, hipStream_t stream) {
+    int threads = min(256, cols);
+    kernel_softmax<<<rows, threads, 0, stream>>>(x, rows, cols);
+}
+
+void flux_rocm_kernel_gated_add(float *out, const float *gate, const float *proj,
+                                int seq, int hidden, hipStream_t stream) {
+    int total = seq * hidden;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    kernel_gated_add<<<blocks, threads, 0, stream>>>(out, gate, proj, seq, hidden);
+}
+
+void flux_rocm_kernel_rope_2d(float *x, const float *cos_freq, const float *sin_freq,
+                              int seq, int heads, int head_dim, int axis_dim, hipStream_t stream) {
+    int pairs_per_head = axis_dim / 2;
+    int total_pairs = seq * heads * pairs_per_head;
+    int threads = 256;
+    int blocks = (total_pairs + threads - 1) / threads;
+    kernel_rope_2d<<<blocks, threads, 0, stream>>>(x, cos_freq, sin_freq, seq, heads, head_dim, axis_dim);
+}
+
+void flux_rocm_kernel_rope_unified(float *q, float *k,
+                                   const float *txt_cos, const float *txt_sin,
+                                   const float *img_cos, const float *img_sin,
+                                   int seq, int img_offset, int heads, int head_dim, int axis_dim,
+                                   hipStream_t stream) {
+    int pairs_per_head = axis_dim / 2;
+    int total_pairs = seq * heads * pairs_per_head;
+    int threads = 256;
+    int blocks = (total_pairs + threads - 1) / threads;
+    kernel_rope_unified<<<blocks, threads, 0, stream>>>(q, k, txt_cos, txt_sin, img_cos, img_sin,
+                                                        seq, img_offset, heads, head_dim, axis_dim);
+}
+
+void flux_rocm_kernel_transpose_to_heads(float *out, const float *in,
+                                         int seq, int heads, int head_dim,
+                                         hipStream_t stream) {
+    int total = seq * heads * head_dim;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    kernel_transpose_to_heads<<<blocks, threads, 0, stream>>>(out, in, seq, heads, head_dim);
+}
+
+void flux_rocm_kernel_transpose_from_heads(float *out, const float *in,
+                                           int seq, int heads, int head_dim,
+                                           hipStream_t stream) {
+    int total = seq * heads * head_dim;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    kernel_transpose_from_heads<<<blocks, threads, 0, stream>>>(out, in, seq, heads, head_dim);
+}
+
+} /* extern "C" */

--- a/rocm/test_kernels.cpp
+++ b/rocm/test_kernels.cpp
@@ -1,0 +1,678 @@
+/*
+ * ROCm Custom Kernel Tests
+ * 
+ * Tests for silu, rms_norm, softmax, rope, etc.
+ */
+
+#include "flux_rocm.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <chrono>
+
+static float* gpu_ptr(flux_rocm_tensor_t t) {
+    return (float*)flux_rocm_tensor_gpu_ptr(t);
+}
+
+/* ========================================================================
+ * CPU Reference Implementations
+ * ======================================================================== */
+
+static void cpu_silu(float *x, int n) {
+    for (int i = 0; i < n; i++) {
+        x[i] = x[i] / (1.0f + expf(-x[i]));
+    }
+}
+
+static void cpu_silu_mul(float *gate, const float *up, int n) {
+    for (int i = 0; i < n; i++) {
+        float g = gate[i];
+        gate[i] = (g / (1.0f + expf(-g))) * up[i];
+    }
+}
+
+static void cpu_rms_norm(float *out, const float *x, const float *weight,
+                         int seq_len, int hidden, float eps) {
+    for (int s = 0; s < seq_len; s++) {
+        const float *row = x + s * hidden;
+        float *out_row = out + s * hidden;
+        
+        float sum_sq = 0;
+        for (int i = 0; i < hidden; i++) {
+            sum_sq += row[i] * row[i];
+        }
+        float rms_inv = 1.0f / sqrtf(sum_sq / hidden + eps);
+        
+        for (int i = 0; i < hidden; i++) {
+            out_row[i] = row[i] * rms_inv * weight[i];
+        }
+    }
+}
+
+static void cpu_softmax(float *x, int rows, int cols) {
+    for (int r = 0; r < rows; r++) {
+        float *row = x + r * cols;
+        
+        float max_val = row[0];
+        for (int i = 1; i < cols; i++) {
+            if (row[i] > max_val) max_val = row[i];
+        }
+        
+        float sum = 0;
+        for (int i = 0; i < cols; i++) {
+            row[i] = expf(row[i] - max_val);
+            sum += row[i];
+        }
+        
+        for (int i = 0; i < cols; i++) {
+            row[i] /= sum;
+        }
+    }
+}
+
+static void cpu_adaln_norm(float *out, const float *x,
+                           const float *shift, const float *scale,
+                           int seq_len, int hidden, float eps) {
+    for (int s = 0; s < seq_len; s++) {
+        const float *row = x + s * hidden;
+        float *out_row = out + s * hidden;
+        
+        /* Mean */
+        float mean = 0;
+        for (int i = 0; i < hidden; i++) mean += row[i];
+        mean /= hidden;
+        
+        /* Variance */
+        float var = 0;
+        for (int i = 0; i < hidden; i++) {
+            float diff = row[i] - mean;
+            var += diff * diff;
+        }
+        var /= hidden;
+        float var_inv = 1.0f / sqrtf(var + eps);
+        
+        /* Apply */
+        for (int i = 0; i < hidden; i++) {
+            float norm = (row[i] - mean) * var_inv;
+            out_row[i] = (1.0f + scale[i]) * norm + shift[i];
+        }
+    }
+}
+
+/* ========================================================================
+ * Test Functions
+ * ======================================================================== */
+
+static float max_diff(const float *a, const float *b, int n) {
+    float max_d = 0;
+    for (int i = 0; i < n; i++) {
+        float d = fabsf(a[i] - b[i]);
+        if (d > max_d) max_d = d;
+    }
+    return max_d;
+}
+
+static int test_silu() {
+    printf("Testing SiLU... ");
+    
+    const int n = 1024 * 1024;
+    float *x_cpu = (float*)malloc(n * sizeof(float));
+    float *x_gpu_out = (float*)malloc(n * sizeof(float));
+    
+    for (int i = 0; i < n; i++) {
+        x_cpu[i] = (float)(i % 100) / 50.0f - 1.0f;  /* Range [-1, 1] */
+    }
+    
+    /* GPU */
+    flux_rocm_tensor_t t_x = flux_rocm_tensor_create(x_cpu, n);
+    flux_rocm_silu(gpu_ptr(t_x), n);
+    flux_rocm_sync();
+    flux_rocm_tensor_read(t_x, x_gpu_out, n);
+    
+    /* CPU reference */
+    cpu_silu(x_cpu, n);
+    
+    float diff = max_diff(x_cpu, x_gpu_out, n);
+    
+    flux_rocm_tensor_free(t_x);
+    free(x_cpu);
+    free(x_gpu_out);
+    
+    if (diff < 1e-5) {
+        printf("PASS (max diff: %.2e)\n", diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", diff);
+        return 0;
+    }
+}
+
+static int test_silu_mul() {
+    printf("Testing SiLU multiply... ");
+    
+    const int n = 1024 * 1024;
+    float *gate_cpu = (float*)malloc(n * sizeof(float));
+    float *up = (float*)malloc(n * sizeof(float));
+    float *gate_gpu_out = (float*)malloc(n * sizeof(float));
+    
+    for (int i = 0; i < n; i++) {
+        gate_cpu[i] = (float)(i % 100) / 50.0f - 1.0f;
+        up[i] = (float)((i * 7) % 100) / 50.0f - 1.0f;
+    }
+    
+    /* GPU */
+    flux_rocm_tensor_t t_gate = flux_rocm_tensor_create(gate_cpu, n);
+    flux_rocm_tensor_t t_up = flux_rocm_tensor_create(up, n);
+    flux_rocm_silu_mul(gpu_ptr(t_gate), gpu_ptr(t_up), n);
+    flux_rocm_sync();
+    flux_rocm_tensor_read(t_gate, gate_gpu_out, n);
+    
+    /* CPU reference */
+    cpu_silu_mul(gate_cpu, up, n);
+    
+    float diff = max_diff(gate_cpu, gate_gpu_out, n);
+    
+    flux_rocm_tensor_free(t_gate);
+    flux_rocm_tensor_free(t_up);
+    free(gate_cpu);
+    free(up);
+    free(gate_gpu_out);
+    
+    if (diff < 1e-5) {
+        printf("PASS (max diff: %.2e)\n", diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", diff);
+        return 0;
+    }
+}
+
+static int test_rms_norm() {
+    printf("Testing RMSNorm... ");
+    
+    const int seq = 512, hidden = 3072;
+    const float eps = 1e-6f;
+    
+    float *x = (float*)malloc(seq * hidden * sizeof(float));
+    float *weight = (float*)malloc(hidden * sizeof(float));
+    float *out_cpu = (float*)malloc(seq * hidden * sizeof(float));
+    float *out_gpu = (float*)malloc(seq * hidden * sizeof(float));
+    
+    for (int i = 0; i < seq * hidden; i++) {
+        x[i] = (float)(i % 1000) / 500.0f - 1.0f;
+    }
+    for (int i = 0; i < hidden; i++) {
+        weight[i] = 1.0f + (float)(i % 10) / 100.0f;
+    }
+    
+    /* GPU */
+    flux_rocm_tensor_t t_x = flux_rocm_tensor_create(x, seq * hidden);
+    flux_rocm_tensor_t t_out = flux_rocm_tensor_alloc(seq * hidden);
+    flux_rocm_tensor_t t_w = flux_rocm_tensor_create(weight, hidden);
+    
+    flux_rocm_rms_norm(gpu_ptr(t_out), gpu_ptr(t_x), gpu_ptr(t_w), seq, hidden, eps);
+    flux_rocm_sync();
+    flux_rocm_tensor_read(t_out, out_gpu, seq * hidden);
+    
+    /* CPU reference */
+    cpu_rms_norm(out_cpu, x, weight, seq, hidden, eps);
+    
+    float diff = max_diff(out_cpu, out_gpu, seq * hidden);
+    
+    flux_rocm_tensor_free(t_x);
+    flux_rocm_tensor_free(t_out);
+    flux_rocm_tensor_free(t_w);
+    free(x); free(weight); free(out_cpu); free(out_gpu);
+    
+    if (diff < 1e-4) {
+        printf("PASS (max diff: %.2e)\n", diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", diff);
+        return 0;
+    }
+}
+
+static int test_softmax() {
+    printf("Testing Softmax... ");
+    
+    const int rows = 768, cols = 768;  /* Attention matrix size */
+    
+    float *x_cpu = (float*)malloc(rows * cols * sizeof(float));
+    float *x_gpu_out = (float*)malloc(rows * cols * sizeof(float));
+    
+    for (int i = 0; i < rows * cols; i++) {
+        x_cpu[i] = (float)(i % 1000) / 100.0f - 5.0f;  /* Range [-5, 5] */
+    }
+    
+    /* GPU */
+    flux_rocm_tensor_t t_x = flux_rocm_tensor_create(x_cpu, rows * cols);
+    flux_rocm_softmax(gpu_ptr(t_x), rows, cols);
+    flux_rocm_sync();
+    flux_rocm_tensor_read(t_x, x_gpu_out, rows * cols);
+    
+    /* CPU reference */
+    cpu_softmax(x_cpu, rows, cols);
+    
+    float diff = max_diff(x_cpu, x_gpu_out, rows * cols);
+    
+    flux_rocm_tensor_free(t_x);
+    free(x_cpu);
+    free(x_gpu_out);
+    
+    if (diff < 1e-5) {
+        printf("PASS (max diff: %.2e)\n", diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", diff);
+        return 0;
+    }
+}
+
+static int test_adaln_norm() {
+    printf("Testing AdaLN... ");
+    
+    const int seq = 256, hidden = 3072;
+    const float eps = 1e-6f;
+    
+    float *x = (float*)malloc(seq * hidden * sizeof(float));
+    float *shift = (float*)malloc(hidden * sizeof(float));
+    float *scale = (float*)malloc(hidden * sizeof(float));
+    float *out_cpu = (float*)malloc(seq * hidden * sizeof(float));
+    float *out_gpu = (float*)malloc(seq * hidden * sizeof(float));
+    
+    for (int i = 0; i < seq * hidden; i++) {
+        x[i] = (float)(i % 1000) / 500.0f - 1.0f;
+    }
+    for (int i = 0; i < hidden; i++) {
+        shift[i] = (float)(i % 100) / 1000.0f;
+        scale[i] = (float)(i % 50) / 500.0f;
+    }
+    
+    /* GPU */
+    flux_rocm_tensor_t t_x = flux_rocm_tensor_create(x, seq * hidden);
+    flux_rocm_tensor_t t_out = flux_rocm_tensor_alloc(seq * hidden);
+    flux_rocm_tensor_t t_shift = flux_rocm_tensor_create(shift, hidden);
+    flux_rocm_tensor_t t_scale = flux_rocm_tensor_create(scale, hidden);
+    
+    flux_rocm_adaln_norm(gpu_ptr(t_out), gpu_ptr(t_x), 
+                         gpu_ptr(t_shift), gpu_ptr(t_scale),
+                         seq, hidden, eps);
+    flux_rocm_sync();
+    flux_rocm_tensor_read(t_out, out_gpu, seq * hidden);
+    
+    /* CPU reference */
+    cpu_adaln_norm(out_cpu, x, shift, scale, seq, hidden, eps);
+    
+    float diff = max_diff(out_cpu, out_gpu, seq * hidden);
+    
+    flux_rocm_tensor_free(t_x);
+    flux_rocm_tensor_free(t_out);
+    flux_rocm_tensor_free(t_shift);
+    flux_rocm_tensor_free(t_scale);
+    free(x); free(shift); free(scale); free(out_cpu); free(out_gpu);
+    
+    if (diff < 1e-4) {
+        printf("PASS (max diff: %.2e)\n", diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", diff);
+        return 0;
+    }
+}
+
+/* ========================================================================
+ * RoPE Tests
+ * ======================================================================== */
+
+static void cpu_rope_2d(float *x, const float *cos_freq, const float *sin_freq,
+                        int seq, int heads, int head_dim, int axis_dim) {
+    int pairs_per_head = axis_dim / 2;
+    
+    for (int s = 0; s < seq; s++) {
+        for (int h = 0; h < heads; h++) {
+            for (int p = 0; p < pairs_per_head; p++) {
+                int x_idx = s * (heads * head_dim) + h * head_dim + p * 2;
+                int freq_idx = s * pairs_per_head + p;
+                
+                float x0 = x[x_idx];
+                float x1 = x[x_idx + 1];
+                float cos_val = cos_freq[freq_idx];
+                float sin_val = sin_freq[freq_idx];
+                
+                x[x_idx]     = x0 * cos_val - x1 * sin_val;
+                x[x_idx + 1] = x0 * sin_val + x1 * cos_val;
+            }
+        }
+    }
+}
+
+/* ========================================================================
+ * Attention Test
+ * ======================================================================== */
+
+static void cpu_attention(float *out, const float *Q, const float *K, const float *V,
+                          int seq_q, int seq_k, int num_heads, int head_dim, float scale) {
+    int hidden = num_heads * head_dim;
+    
+    /* For each head */
+    for (int h = 0; h < num_heads; h++) {
+        /* Compute scores = Q @ K^T * scale */
+        float *scores = (float*)malloc(seq_q * seq_k * sizeof(float));
+        
+        for (int sq = 0; sq < seq_q; sq++) {
+            for (int sk = 0; sk < seq_k; sk++) {
+                float sum = 0;
+                for (int d = 0; d < head_dim; d++) {
+                    float q_val = Q[sq * hidden + h * head_dim + d];
+                    float k_val = K[sk * hidden + h * head_dim + d];
+                    sum += q_val * k_val;
+                }
+                scores[sq * seq_k + sk] = sum * scale;
+            }
+        }
+        
+        /* Softmax per row */
+        for (int sq = 0; sq < seq_q; sq++) {
+            float max_val = scores[sq * seq_k];
+            for (int sk = 1; sk < seq_k; sk++) {
+                if (scores[sq * seq_k + sk] > max_val) 
+                    max_val = scores[sq * seq_k + sk];
+            }
+            
+            float sum = 0;
+            for (int sk = 0; sk < seq_k; sk++) {
+                scores[sq * seq_k + sk] = expf(scores[sq * seq_k + sk] - max_val);
+                sum += scores[sq * seq_k + sk];
+            }
+            for (int sk = 0; sk < seq_k; sk++) {
+                scores[sq * seq_k + sk] /= sum;
+            }
+        }
+        
+        /* out = scores @ V */
+        for (int sq = 0; sq < seq_q; sq++) {
+            for (int d = 0; d < head_dim; d++) {
+                float sum = 0;
+                for (int sk = 0; sk < seq_k; sk++) {
+                    float score = scores[sq * seq_k + sk];
+                    float v_val = V[sk * hidden + h * head_dim + d];
+                    sum += score * v_val;
+                }
+                out[sq * hidden + h * head_dim + d] = sum;
+            }
+        }
+        
+        free(scores);
+    }
+}
+
+static int test_attention() {
+    printf("Testing Attention... ");
+    
+    const int seq = 64, num_heads = 8, head_dim = 64;
+    const int hidden = num_heads * head_dim;
+    const float scale = 1.0f / sqrtf((float)head_dim);
+    
+    float *Q = (float*)malloc(seq * hidden * sizeof(float));
+    float *K = (float*)malloc(seq * hidden * sizeof(float));
+    float *V = (float*)malloc(seq * hidden * sizeof(float));
+    float *out_cpu = (float*)malloc(seq * hidden * sizeof(float));
+    float *out_gpu = (float*)malloc(seq * hidden * sizeof(float));
+    
+    /* Initialize with small values to avoid numerical issues */
+    for (int i = 0; i < seq * hidden; i++) {
+        Q[i] = (float)((i * 7) % 100) / 500.0f - 0.1f;
+        K[i] = (float)((i * 11) % 100) / 500.0f - 0.1f;
+        V[i] = (float)((i * 13) % 100) / 500.0f - 0.1f;
+    }
+    
+    /* CPU reference */
+    cpu_attention(out_cpu, Q, K, V, seq, seq, num_heads, head_dim, scale);
+    
+    /* GPU */
+    flux_rocm_tensor_t t_Q = flux_rocm_tensor_create(Q, seq * hidden);
+    flux_rocm_tensor_t t_K = flux_rocm_tensor_create(K, seq * hidden);
+    flux_rocm_tensor_t t_V = flux_rocm_tensor_create(V, seq * hidden);
+    flux_rocm_tensor_t t_out = flux_rocm_tensor_alloc(seq * hidden);
+    
+    int ok = flux_rocm_attention_fused(gpu_ptr(t_out), gpu_ptr(t_Q), gpu_ptr(t_K), gpu_ptr(t_V),
+                                       seq, seq, num_heads, head_dim, scale);
+    
+    if (!ok) {
+        printf("FAIL (attention returned error)\n");
+        flux_rocm_tensor_free(t_Q);
+        flux_rocm_tensor_free(t_K);
+        flux_rocm_tensor_free(t_V);
+        flux_rocm_tensor_free(t_out);
+        free(Q); free(K); free(V); free(out_cpu); free(out_gpu);
+        return 0;
+    }
+    
+    flux_rocm_sync();
+    flux_rocm_tensor_read(t_out, out_gpu, seq * hidden);
+    
+    float diff = max_diff(out_cpu, out_gpu, seq * hidden);
+    
+    flux_rocm_tensor_free(t_Q);
+    flux_rocm_tensor_free(t_K);
+    flux_rocm_tensor_free(t_V);
+    flux_rocm_tensor_free(t_out);
+    free(Q); free(K); free(V); free(out_cpu); free(out_gpu);
+    
+    if (diff < 1e-4) {
+        printf("PASS (max diff: %.2e)\n", diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", diff);
+        return 0;
+    }
+}
+
+static int test_rope_2d() {
+    printf("Testing RoPE 2D... ");
+    
+    const int seq = 256, heads = 24, head_dim = 128, axis_dim = 32;
+    const int pairs_per_head = axis_dim / 2;
+    
+    float *x_cpu = (float*)malloc(seq * heads * head_dim * sizeof(float));
+    float *x_gpu_out = (float*)malloc(seq * heads * head_dim * sizeof(float));
+    float *cos_freq = (float*)malloc(seq * pairs_per_head * sizeof(float));
+    float *sin_freq = (float*)malloc(seq * pairs_per_head * sizeof(float));
+    
+    /* Initialize */
+    for (int i = 0; i < seq * heads * head_dim; i++) {
+        x_cpu[i] = (float)(i % 1000) / 500.0f - 1.0f;
+    }
+    for (int i = 0; i < seq * pairs_per_head; i++) {
+        float angle = (float)i * 0.01f;
+        cos_freq[i] = cosf(angle);
+        sin_freq[i] = sinf(angle);
+    }
+    
+    /* GPU */
+    flux_rocm_tensor_t t_x = flux_rocm_tensor_create(x_cpu, seq * heads * head_dim);
+    flux_rocm_tensor_t t_cos = flux_rocm_tensor_create(cos_freq, seq * pairs_per_head);
+    flux_rocm_tensor_t t_sin = flux_rocm_tensor_create(sin_freq, seq * pairs_per_head);
+    
+    flux_rocm_rope_2d(gpu_ptr(t_x), gpu_ptr(t_cos), gpu_ptr(t_sin),
+                      seq, heads, head_dim, axis_dim);
+    flux_rocm_sync();
+    flux_rocm_tensor_read(t_x, x_gpu_out, seq * heads * head_dim);
+    
+    /* CPU reference */
+    cpu_rope_2d(x_cpu, cos_freq, sin_freq, seq, heads, head_dim, axis_dim);
+    
+    float diff = max_diff(x_cpu, x_gpu_out, seq * heads * head_dim);
+    
+    flux_rocm_tensor_free(t_x);
+    flux_rocm_tensor_free(t_cos);
+    flux_rocm_tensor_free(t_sin);
+    free(x_cpu); free(x_gpu_out); free(cos_freq); free(sin_freq);
+    
+    if (diff < 1e-5) {
+        printf("PASS (max diff: %.2e)\n", diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", diff);
+        return 0;
+    }
+}
+
+/* ========================================================================
+ * Performance Benchmarks
+ * ======================================================================== */
+
+static void bench_kernels() {
+    printf("\nKernel Performance Benchmarks:\n");
+    
+    const int seq = 768, hidden = 3072;
+    const int iters = 100;
+    
+    flux_rocm_tensor_t x = flux_rocm_tensor_alloc(seq * hidden);
+    flux_rocm_tensor_t out = flux_rocm_tensor_alloc(seq * hidden);
+    flux_rocm_tensor_t weight = flux_rocm_tensor_alloc(hidden);
+    flux_rocm_tensor_t gate = flux_rocm_tensor_alloc(seq * hidden);
+    flux_rocm_tensor_t up = flux_rocm_tensor_alloc(seq * hidden);
+    
+    /* Warmup */
+    flux_rocm_silu(gpu_ptr(x), seq * hidden);
+    flux_rocm_sync();
+    
+    /* SiLU */
+    {
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < iters; i++) {
+            flux_rocm_silu(gpu_ptr(x), seq * hidden);
+        }
+        flux_rocm_sync();
+        auto end = std::chrono::high_resolution_clock::now();
+        double us = std::chrono::duration<double, std::micro>(end - start).count() / iters;
+        double gb_s = (seq * hidden * sizeof(float) * 2.0) / (us * 1000.0);  /* read + write */
+        printf("  SiLU (%dx%d): %.1f us (%.1f GB/s)\n", seq, hidden, us, gb_s);
+    }
+    
+    /* SiLU mul */
+    {
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < iters; i++) {
+            flux_rocm_silu_mul(gpu_ptr(gate), gpu_ptr(up), seq * hidden);
+        }
+        flux_rocm_sync();
+        auto end = std::chrono::high_resolution_clock::now();
+        double us = std::chrono::duration<double, std::micro>(end - start).count() / iters;
+        double gb_s = (seq * hidden * sizeof(float) * 3.0) / (us * 1000.0);
+        printf("  SiLU*mul (%dx%d): %.1f us (%.1f GB/s)\n", seq, hidden, us, gb_s);
+    }
+    
+    /* RMSNorm */
+    {
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < iters; i++) {
+            flux_rocm_rms_norm(gpu_ptr(out), gpu_ptr(x), gpu_ptr(weight), seq, hidden, 1e-6f);
+        }
+        flux_rocm_sync();
+        auto end = std::chrono::high_resolution_clock::now();
+        double us = std::chrono::duration<double, std::micro>(end - start).count() / iters;
+        printf("  RMSNorm (%dx%d): %.1f us\n", seq, hidden, us);
+    }
+    
+    /* Softmax */
+    {
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < iters; i++) {
+            flux_rocm_softmax(gpu_ptr(x), seq, seq);
+        }
+        flux_rocm_sync();
+        auto end = std::chrono::high_resolution_clock::now();
+        double us = std::chrono::duration<double, std::micro>(end - start).count() / iters;
+        printf("  Softmax (%dx%d): %.1f us\n", seq, seq, us);
+    }
+    
+    /* AdaLN */
+    {
+        flux_rocm_tensor_t shift = flux_rocm_tensor_alloc(hidden);
+        flux_rocm_tensor_t scale = flux_rocm_tensor_alloc(hidden);
+        
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < iters; i++) {
+            flux_rocm_adaln_norm(gpu_ptr(out), gpu_ptr(x), 
+                                 gpu_ptr(shift), gpu_ptr(scale),
+                                 seq, hidden, 1e-6f);
+        }
+        flux_rocm_sync();
+        auto end = std::chrono::high_resolution_clock::now();
+        double us = std::chrono::duration<double, std::micro>(end - start).count() / iters;
+        printf("  AdaLN (%dx%d): %.1f us\n", seq, hidden, us);
+        
+        flux_rocm_tensor_free(shift);
+        flux_rocm_tensor_free(scale);
+    }
+    
+    flux_rocm_tensor_free(x);
+    flux_rocm_tensor_free(out);
+    flux_rocm_tensor_free(weight);
+    flux_rocm_tensor_free(gate);
+    flux_rocm_tensor_free(up);
+    
+    /* Attention benchmark */
+    {
+        const int attn_seq = 768, attn_heads = 24, attn_head_dim = 128;
+        const int attn_hidden = attn_heads * attn_head_dim;
+        const float attn_scale = 1.0f / sqrtf((float)attn_head_dim);
+        
+        flux_rocm_tensor_t Q = flux_rocm_tensor_alloc(attn_seq * attn_hidden);
+        flux_rocm_tensor_t K = flux_rocm_tensor_alloc(attn_seq * attn_hidden);
+        flux_rocm_tensor_t V = flux_rocm_tensor_alloc(attn_seq * attn_hidden);
+        flux_rocm_tensor_t attn_out = flux_rocm_tensor_alloc(attn_seq * attn_hidden);
+        
+        /* Warmup */
+        flux_rocm_attention_fused(gpu_ptr(attn_out), gpu_ptr(Q), gpu_ptr(K), gpu_ptr(V),
+                                  attn_seq, attn_seq, attn_heads, attn_head_dim, attn_scale);
+        flux_rocm_sync();
+        
+        const int attn_iters = 20;
+        auto start = std::chrono::high_resolution_clock::now();
+        for (int i = 0; i < attn_iters; i++) {
+            flux_rocm_attention_fused(gpu_ptr(attn_out), gpu_ptr(Q), gpu_ptr(K), gpu_ptr(V),
+                                      attn_seq, attn_seq, attn_heads, attn_head_dim, attn_scale);
+        }
+        flux_rocm_sync();
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms = std::chrono::duration<double, std::milli>(end - start).count() / attn_iters;
+        
+        printf("  Attention (seq=%d, heads=%d): %.2f ms\n", attn_seq, attn_heads, ms);
+        
+        flux_rocm_tensor_free(Q);
+        flux_rocm_tensor_free(K);
+        flux_rocm_tensor_free(V);
+        flux_rocm_tensor_free(attn_out);
+    }
+}
+
+int main() {
+    printf("=== FLUX ROCm Kernel Test ===\n\n");
+    
+    if (!flux_rocm_init()) {
+        printf("Failed to initialize ROCm\n");
+        return 1;
+    }
+    
+    int passed = 0, total = 0;
+    
+    total++; if (test_silu()) passed++;
+    total++; if (test_silu_mul()) passed++;
+    total++; if (test_rms_norm()) passed++;
+    total++; if (test_softmax()) passed++;
+    total++; if (test_adaln_norm()) passed++;
+    total++; if (test_attention()) passed++;
+    total++; if (test_rope_2d()) passed++;
+    
+    bench_kernels();
+    
+    printf("\n=== Results: %d/%d tests passed ===\n", passed, total);
+    
+    flux_rocm_cleanup();
+    
+    return (passed == total) ? 0 : 1;
+}

--- a/rocm/test_match.cpp
+++ b/rocm/test_match.cpp
@@ -1,0 +1,55 @@
+#include "flux_rocm.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <cblas.h>
+
+int main() {
+    flux_rocm_init();
+    
+    // Match actual dimensions from flux
+    const int seq = 512, in_dim = 3072, out_dim = 3072;
+    
+    float *x = (float*)malloc(seq * in_dim * sizeof(float));
+    float *W = (float*)malloc(out_dim * in_dim * sizeof(float));
+    float *y_blas = (float*)malloc(seq * out_dim * sizeof(float));
+    float *y_rocm = (float*)malloc(seq * out_dim * sizeof(float));
+    
+    // Random init
+    for (int i = 0; i < seq * in_dim; i++) x[i] = (float)(rand() % 1000) / 1000.0f - 0.5f;
+    for (int i = 0; i < out_dim * in_dim; i++) W[i] = (float)(rand() % 1000) / 10000.0f - 0.05f;
+    
+    // BLAS: y = x @ W^T
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                seq, out_dim, in_dim,
+                1.0f, x, in_dim, W, in_dim,
+                0.0f, y_blas, out_dim);
+    
+    // ROCm
+    flux_rocm_tensor_t t_x = flux_rocm_tensor_create(x, seq * in_dim);
+    flux_rocm_tensor_t t_y = flux_rocm_linear(t_x, W, seq, in_dim, out_dim);
+    if (t_y) {
+        flux_rocm_tensor_read(t_y, y_rocm, seq * out_dim);
+        flux_rocm_tensor_free(t_y);
+    }
+    flux_rocm_tensor_free(t_x);
+    
+    // Compare
+    float max_diff = 0, avg_diff = 0;
+    int bad_count = 0;
+    for (int i = 0; i < seq * out_dim; i++) {
+        float diff = fabsf(y_blas[i] - y_rocm[i]);
+        if (diff > max_diff) max_diff = diff;
+        avg_diff += diff;
+        if (diff > 0.01) bad_count++;
+    }
+    avg_diff /= (seq * out_dim);
+    
+    printf("BLAS first 5: %.4f %.4f %.4f %.4f %.4f\n", y_blas[0], y_blas[1], y_blas[2], y_blas[3], y_blas[4]);
+    printf("ROCm first 5: %.4f %.4f %.4f %.4f %.4f\n", y_rocm[0], y_rocm[1], y_rocm[2], y_rocm[3], y_rocm[4]);
+    printf("Max diff: %.6f, Avg diff: %.6f, Bad count: %d/%d\n", max_diff, avg_diff, bad_count, seq*out_dim);
+    
+    free(x); free(W); free(y_blas); free(y_rocm);
+    flux_rocm_cleanup();
+    return (max_diff > 0.01) ? 1 : 0;
+}

--- a/rocm/test_rocm.cpp
+++ b/rocm/test_rocm.cpp
@@ -1,0 +1,283 @@
+/*
+ * Simple ROCm infrastructure test
+ * 
+ * Build: hipcc -O2 -o test_rocm test_rocm.cpp flux_rocm.cpp -lhipblas
+ * Run: ./test_rocm
+ */
+
+#include "flux_rocm.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <chrono>
+
+/* Helper to get float pointer from tensor */
+static float* gpu_ptr(flux_rocm_tensor_t t) {
+    return (float*)flux_rocm_tensor_gpu_ptr(t);
+}
+
+/* Simple SGEMM correctness test */
+static int test_sgemm() {
+    printf("Testing SGEMM... ");
+    
+    const int M = 64, N = 128, K = 256;
+    
+    /* Allocate CPU memory */
+    float *A = (float*)malloc(M * K * sizeof(float));
+    float *B = (float*)malloc(K * N * sizeof(float));
+    float *C_gpu = (float*)malloc(M * N * sizeof(float));
+    float *C_cpu = (float*)malloc(M * N * sizeof(float));
+    
+    /* Initialize with simple pattern */
+    for (int i = 0; i < M * K; i++) A[i] = (float)(i % 7) / 7.0f;
+    for (int i = 0; i < K * N; i++) B[i] = (float)(i % 11) / 11.0f;
+    
+    /* CPU reference: C = A @ B^T (to match our SGEMM call) */
+    for (int i = 0; i < M; i++) {
+        for (int j = 0; j < N; j++) {
+            float sum = 0;
+            for (int k = 0; k < K; k++) {
+                sum += A[i * K + k] * B[j * K + k];  /* B^T means B[j,k] = B[j*K+k] */
+            }
+            C_cpu[i * N + j] = sum;
+        }
+    }
+    
+    /* GPU: Upload data */
+    flux_rocm_tensor_t t_A = flux_rocm_tensor_create(A, M * K);
+    flux_rocm_tensor_t t_B = flux_rocm_tensor_create(B, K * N);
+    flux_rocm_tensor_t t_C = flux_rocm_tensor_alloc(M * N);
+    
+    if (!t_A || !t_B || !t_C) {
+        printf("FAIL (tensor alloc)\n");
+        return 0;
+    }
+    
+    /* Run SGEMM: C = A @ B^T */
+    flux_rocm_sgemm(0, 1,  /* no trans A, trans B */
+                    M, N, K,
+                    1.0f,
+                    gpu_ptr(t_A), K,
+                    gpu_ptr(t_B), K,
+                    0.0f,
+                    gpu_ptr(t_C), N);
+    
+    /* Read back */
+    flux_rocm_tensor_read(t_C, C_gpu, M * N);
+    
+    /* Compare */
+    float max_diff = 0;
+    for (int i = 0; i < M * N; i++) {
+        float diff = fabsf(C_gpu[i] - C_cpu[i]);
+        if (diff > max_diff) max_diff = diff;
+    }
+    
+    flux_rocm_tensor_free(t_A);
+    flux_rocm_tensor_free(t_B);
+    flux_rocm_tensor_free(t_C);
+    free(A); free(B); free(C_gpu); free(C_cpu);
+    
+    if (max_diff < 1e-4) {
+        printf("PASS (max diff: %.2e)\n", max_diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", max_diff);
+        return 0;
+    }
+}
+
+/* SGEMM performance test */
+static void test_sgemm_perf() {
+    printf("\nSGEMM Performance Test:\n");
+    
+    /* Test sizes similar to transformer ops */
+    struct { int M, N, K; const char *desc; } tests[] = {
+        {768, 3072, 3072, "Linear (seq=768, hidden=3072)"},
+        {768, 9216, 3072, "FFN up (seq=768, 3072->9216)"},
+        {768, 3072, 9216, "FFN down (seq=768, 9216->3072)"},
+        {256, 3072, 3072, "Linear (seq=256)"},
+        {1024, 3072, 3072, "Linear (seq=1024)"},
+    };
+    
+    for (auto &t : tests) {
+        int M = t.M, N = t.N, K = t.K;
+        
+        /* Allocate */
+        flux_rocm_tensor_t A = flux_rocm_tensor_alloc(M * K);
+        flux_rocm_tensor_t B = flux_rocm_tensor_alloc(K * N);
+        flux_rocm_tensor_t C = flux_rocm_tensor_alloc(M * N);
+        
+        if (!A || !B || !C) {
+            printf("  %s: SKIP (alloc failed)\n", t.desc);
+            continue;
+        }
+        
+        /* Warmup */
+        flux_rocm_sgemm(0, 1, M, N, K, 1.0f,
+                        gpu_ptr(A), K,
+                        gpu_ptr(B), K,
+                        0.0f,
+                        gpu_ptr(C), N);
+        flux_rocm_sync();
+        
+        /* Benchmark */
+        const int iters = 50;
+        auto start = std::chrono::high_resolution_clock::now();
+        
+        for (int i = 0; i < iters; i++) {
+            flux_rocm_sgemm(0, 1, M, N, K, 1.0f,
+                            gpu_ptr(A), K,
+                            gpu_ptr(B), K,
+                            0.0f,
+                            gpu_ptr(C), N);
+        }
+        flux_rocm_sync();
+        
+        auto end = std::chrono::high_resolution_clock::now();
+        double ms = std::chrono::duration<double, std::milli>(end - start).count() / iters;
+        
+        /* Compute TFLOPS */
+        double flops = 2.0 * M * N * K;  /* 2 ops per multiply-add */
+        double tflops = (flops / 1e12) / (ms / 1000.0);
+        
+        printf("  %s: %.2f ms (%.1f TFLOPS)\n", t.desc, ms, tflops);
+        
+        flux_rocm_tensor_free(A);
+        flux_rocm_tensor_free(B);
+        flux_rocm_tensor_free(C);
+    }
+}
+
+/* Linear layer test */
+static int test_linear() {
+    printf("Testing Linear layer... ");
+    
+    const int seq = 64, in_dim = 256, out_dim = 512;
+    
+    float *x = (float*)malloc(seq * in_dim * sizeof(float));
+    float *W = (float*)malloc(out_dim * in_dim * sizeof(float));
+    float *out_cpu = (float*)malloc(seq * out_dim * sizeof(float));
+    float *out_gpu = (float*)malloc(seq * out_dim * sizeof(float));
+    
+    /* Initialize */
+    for (int i = 0; i < seq * in_dim; i++) x[i] = (float)(i % 13) / 13.0f;
+    for (int i = 0; i < out_dim * in_dim; i++) W[i] = (float)(i % 17) / 17.0f;
+    
+    /* CPU reference: out = x @ W^T */
+    for (int s = 0; s < seq; s++) {
+        for (int o = 0; o < out_dim; o++) {
+            float sum = 0;
+            for (int i = 0; i < in_dim; i++) {
+                sum += x[s * in_dim + i] * W[o * in_dim + i];
+            }
+            out_cpu[s * out_dim + o] = sum;
+        }
+    }
+    
+    /* GPU */
+    flux_rocm_tensor_t t_x = flux_rocm_tensor_create(x, seq * in_dim);
+    flux_rocm_tensor_t t_out = flux_rocm_linear(t_x, W, seq, in_dim, out_dim);
+    
+    if (!t_out) {
+        printf("FAIL (linear returned null)\n");
+        flux_rocm_tensor_free(t_x);
+        free(x); free(W); free(out_cpu); free(out_gpu);
+        return 0;
+    }
+    
+    flux_rocm_tensor_read(t_out, out_gpu, seq * out_dim);
+    
+    /* Compare */
+    float max_diff = 0;
+    for (int i = 0; i < seq * out_dim; i++) {
+        float diff = fabsf(out_gpu[i] - out_cpu[i]);
+        if (diff > max_diff) max_diff = diff;
+    }
+    
+    flux_rocm_tensor_free(t_x);
+    flux_rocm_tensor_free(t_out);
+    free(x); free(W); free(out_cpu); free(out_gpu);
+    
+    if (max_diff < 1e-4) {
+        printf("PASS (max diff: %.2e)\n", max_diff);
+        return 1;
+    } else {
+        printf("FAIL (max diff: %.2e)\n", max_diff);
+        return 0;
+    }
+}
+
+/* Memory test */
+static void test_memory() {
+    printf("\nMemory Management Test:\n");
+    
+    size_t initial = flux_rocm_memory_used();
+    printf("  Initial memory: %zu bytes\n", initial);
+    
+    /* Allocate some tensors */
+    const int N = 10;
+    flux_rocm_tensor_t tensors[N];
+    for (int i = 0; i < N; i++) {
+        tensors[i] = flux_rocm_tensor_alloc(1024 * 1024);  /* 4MB each */
+    }
+    
+    size_t after_alloc = flux_rocm_memory_used();
+    printf("  After allocating %d x 4MB tensors: %zu bytes (%.1f MB)\n", 
+           N, after_alloc, after_alloc / (1024.0 * 1024.0));
+    
+    /* Free half */
+    for (int i = 0; i < N/2; i++) {
+        flux_rocm_tensor_free(tensors[i]);
+        tensors[i] = nullptr;
+    }
+    
+    /* Memory should stay same (pooled) */
+    size_t after_free = flux_rocm_memory_used();
+    printf("  After freeing %d tensors (pooled): %zu bytes\n", N/2, after_free);
+    
+    /* Allocate same size - should reuse */
+    for (int i = 0; i < N/2; i++) {
+        tensors[i] = flux_rocm_tensor_alloc(1024 * 1024);
+    }
+    
+    size_t after_reuse = flux_rocm_memory_used();
+    printf("  After re-allocating (should reuse): %zu bytes\n", after_reuse);
+    
+    /* Cleanup */
+    for (int i = 0; i < N; i++) {
+        if (tensors[i]) flux_rocm_tensor_free(tensors[i]);
+    }
+    
+    /* Reset pool */
+    flux_rocm_reset();
+    size_t after_reset = flux_rocm_memory_used();
+    printf("  After reset: %zu bytes\n", after_reset);
+}
+
+int main() {
+    printf("=== FLUX ROCm Infrastructure Test ===\n\n");
+    
+    /* Initialize */
+    if (!flux_rocm_init()) {
+        printf("Failed to initialize ROCm\n");
+        return 1;
+    }
+    
+    printf("Memory used after init: %zu bytes\n\n", flux_rocm_memory_used());
+    
+    /* Run tests */
+    int passed = 0, total = 0;
+    
+    total++; if (test_sgemm()) passed++;
+    total++; if (test_linear()) passed++;
+    
+    test_sgemm_perf();
+    test_memory();
+    
+    printf("\n=== Results: %d/%d tests passed ===\n", passed, total);
+    
+    /* Cleanup */
+    flux_rocm_cleanup();
+    
+    return (passed == total) ? 0 : 1;
+}


### PR DESCRIPTION
# ROCm Backend: Full GPU-Resident Architecture

Alternative ROCm implementation to #7 with a fundamentally different approach.

@antirez I saw from #7 that you don't have AMD hardware to test, totally understandable. Opening this PR mainly so other AMD users can easily find and try the fork. Happy to help test against any future changes if needed.

This PR was *also* developed with Claude.

## Approach Difference

**PR #7**: Wraps individual BLAS calls - each operation copies data CPU↔GPU, causing PCIe bottleneck.

**This PR**: GPU-resident architecture (like Metal backend) - activations stay on GPU throughout transformer blocks, only transferring at boundaries.

## Whats Implemented

- **GPU Tensor API** - Tensors live on GPU with explicit transfer control
- **Weight Caching** - Upload once, reuse across all forward passes  
- **Buffer Pooling** - No malloc/free in hot paths
- **`single_block_forward_rocm()`** - All 20 single blocks fully on GPU
- **`double_block_forward_rocm()`** - All 5 double blocks with joint attention on GPU
- **Custom HIP kernels** - AdaLN, RoPE, SwiGLU, attention, softmax

Also fixed RoPE kernel bug that was only rotating 32/128 dimensions (75% of rotations were identity).

## Benchmark Results

| Size | BLAS (CPU) | PR #7 | This PR | Speedup |
|------|------------|-------|---------|---------|
| 256×256 | 28.8s | - | **5.0s** | 5.7x |
| 512×512 | 51.6s | 68s | **15.8s** | 4.3x vs #7 |

All outputs verified correct (RMSE < 10 vs BLAS reference).

## Usage

```bash
make rocm
./flux -d flux-klein-model -p "your prompt" -W 256 -H 256 --no-mmap -o out.png
```

## Hardware Tested

- AMD Radeon RX 9070 XT (gfx1201, RDNA 4, 16GB VRAM)
- ROCm 6.x, Arch Linux

**Note**: RDNA 4 uses 32-wide wavefronts (not 64 like GCN/CDNA) - handled in kernels.

## Remaining Optimizations

- Text encoder on GPU (~8s savings)
- bf16 compute pipeline  
- Fused attention kernel

## Notes

- All ROCm code is guarded with `#ifdef USE_ROCM`, non-ROCm builds unaffected
- ROCm files are in `rocm/` subdirectory (vs Metal in root), happy to restructure if preferred