### PR TITLE
fix: limit img2img to 1024px to avoid MPS 4GB attention crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ documents/
 *.a
 *.so
 *.dylib
+
+# Auto-generated files
+flux_shaders_source.h

--- a/flux.h
+++ b/flux.h
@@ -50,6 +50,7 @@ extern "C" {
 #define FLUX_VAE_NUM_RES        2
 #define FLUX_VAE_GROUPS         32
 #define FLUX_VAE_MAX_DIM        1792  /* Max image dimension for VAE */
+#define FLUX_IMG2IMG_MAX_DIM    1024  /* Max dimension for img2img (MPS 4GB attention limit) */
 
 /* Tokenizer */
 #define FLUX_MAX_SEQ_LEN        512


### PR DESCRIPTION
Metal Performance Shaders has a 4GB (2^32 bytes) limit on MPSTemporaryNDArray. For img2img with reference images, the attention score matrix [heads=24, seq_q, seq_k] in bf16 can exceed this limit at high resolutions, causing an assertion failure:
 ```
  [MPSTemporaryNDArray initWithDevice:descriptor:isTextureBacked:]
  Error: total bytes of NDArray > 2**32
 ```
Add FLUX_IMG2IMG_MAX_DIM (1024) constant and enforce it in flux_img2img() and flux_img2img_with_refs(). Images larger than 1024px are automatically resized (preserving aspect ratio) with a user-visible note, allowing full GPU acceleration to continue.
 
The 1024px limit ensures the combined sequence length (target + reference + text tokens)  stays within MPS memory constraints for the attention computation.