### PR TITLE
Use runtime @available check for Metal mathMode API

### DIFF
--- a/flux_metal.m
+++ b/flux_metal.m
@@ -3055,11 +3055,15 @@ int flux_metal_init_shaders(void) {
 
         /* Compile shader library */
         MTLCompileOptions *options = [[MTLCompileOptions alloc] init];
-#if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
-        options.mathMode = MTLMathModeFast;
-#else
-        options.fastMathEnabled = YES;
-#endif
+  #if defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000
+          if (@available(macOS 15.0, *)) {
+              options.mathMode = MTLMathModeFast;
+          } else {
+              options.fastMathEnabled = YES;
+          }
+  #else
+          options.fastMathEnabled = YES;
+  #endif
 
         g_shader_library = [g_device newLibraryWithSource:shaderSource
                                                   options:options


### PR DESCRIPTION
## Problem

The compile-time check works against the macOS 15 SDK and will crash on macOS 14 and below.

This limits the ability to create pre-compiled binaries that support both MacOS 15 and earlier. Switch to runtime check to support multiple OS versions with a single binary.

Solution: Use the `@available` call.