### PR TITLE
Update params.seed when -S is not given

### DIFF
--- a/main.c
+++ b/main.c
@@ -450,6 +450,7 @@ int main(int argc, char *argv[]) {
         actual_seed = params.seed;
     } else {
         actual_seed = (int64_t)time(NULL);
+        params.seed = actual_seed;
     }
     flux_set_seed(actual_seed);
     LOG_NORMAL("Seed: %lld\n", (long long)actual_seed);


### PR DESCRIPTION
This PR fixes the following use case

```
$ ./flux -d flux-klein-4b -p "Some random bug" -W 512 -H 512 -o output.png
...
Seed: 1770589003
...
```

```
$ ./flux -d flux-klein-4b -S 1770589003 -p "Some random bug" -W 512 -H 512 -o output.png
```

Generating different images.
