### PR TITLE
Add web UI for FLUX.2 image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,20 @@ The following metadata fields are stored:
 - `flux:model` - The model name (FLUX.2-klein-4B)
 - `Software` - Program identifier
 
+## Web UI
+
+A browser-based interface is available in the [`webui/`](webui/) directory. It exposes all generation settings, supports image-to-image with multiple references, and tracks tasks with real-time progress — even across page reloads.
+
+```bash
+cd webui
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+See [`webui/README.md`](webui/README.md) for details.
+
 ## Building
 
 Choose a backend when building:

--- a/webui/.gitignore
+++ b/webui/.gitignore
@@ -1,0 +1,8 @@
+.venv/
+.streamlit/
+data/
+outputs/
+uploads/
+__pycache__/
+*.pyc
+.DS_Store

--- a/webui/README.md
+++ b/webui/README.md
@@ -1,0 +1,64 @@
+# FLUX.2 Web UI
+
+A Streamlit interface for the flux image generation binary. Exposes all generation settings in a browser-based UI with persistent task tracking.
+
+![Web UI](https://github.com/user-attachments/assets/placeholder)
+
+## Setup
+
+Requires **Python 3.10+** and the `flux` binary already compiled (see the [main README](../README.md) for build instructions).
+
+```bash
+cd webui
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+streamlit run app.py
+```
+
+The app opens at `http://localhost:8501`. It auto-detects model directories in the project root.
+
+## Features
+
+- **All generation modes**: text-to-image and image-to-image with up to 16 reference images
+- **Every CLI option exposed**: dimensions, steps, seed, guidance, timestep schedule (sigmoid / linear / power curve), force-base, no-mmap
+- **Real-time progress**: live progress bar with phase labels (loading → encoding → denoising steps → decode → save)
+- **Task persistence**: tasks survive page reloads and server restarts — backed by SQLite with WAL journaling
+- **Cancel running tasks**: stop a generation mid-flight from the UI
+- **Image gallery**: browse completed generations with prompt, dimensions, timing, and seed metadata
+- **Save / Delete**: download images or clean up directly from the gallery
+- **Format-agnostic uploads**: any image format (JPEG, PNG, WebP, TIFF, BMP) is converted to PNG before passing to flux
+
+## Architecture
+
+```
+app.py          Streamlit UI — sidebar settings, prompt input, gallery, active tasks
+store.py        SQLite persistence — task lifecycle (create → running → completed/failed)
+flux_runner.py  Background execution — spawns flux in a thread, parses stderr for progress
+```
+
+The app launches `flux` as a subprocess per task. A monitor thread reads stderr with non-blocking I/O and maps the output phases to a 0–100% progress range:
+
+| Range   | Phase              |
+|---------|--------------------|
+| 0–5%    | Loading model      |
+| 5–20%   | Text encoding      |
+| 20–90%  | Denoising steps    |
+| 90–97%  | VAE decode         |
+| 97–100% | Saving             |
+
+On startup, `store.init()` checks for orphaned tasks (process no longer alive) and marks them as failed. The init call is cached via `@st.cache_resource` so Streamlit's auto-reloader doesn't re-trigger it.
+
+## File Layout
+
+```
+webui/
+├── app.py              Main application
+├── store.py            Task database
+├── flux_runner.py      Binary execution + progress parsing
+├── requirements.txt    Python dependencies
+├── .gitignore
+├── data/               SQLite database (gitignored)
+├── outputs/            Generated images (gitignored)
+└── uploads/            Uploaded reference images (gitignored)
+```

--- a/webui/app.py
+++ b/webui/app.py
@@ -1,0 +1,302 @@
+"""FLUX.2 Web UI — Streamlit interface for the flux image generation binary."""
+
+import hashlib
+import os
+import signal
+from datetime import datetime
+from pathlib import Path
+
+import streamlit as st
+from PIL import Image
+
+import store
+import flux_runner
+
+st.set_page_config(page_title="FLUX.2 Generator", layout="wide")
+
+
+@st.cache_resource
+def _init_store():
+    store.init()
+
+
+_init_store()
+
+# ── Prerequisites ─────────────────────────────────────────────────────
+
+if not flux_runner.BINARY.exists():
+    st.error(
+        f"Binary not found at `{flux_runner.BINARY}`. "
+        "Build it first with `make mps` (Apple Silicon) or `make blas` (CPU)."
+    )
+    st.stop()
+
+models = flux_runner.find_models()
+if not models:
+    st.error(
+        "No model directories found. "
+        "Run `./download_model.sh` from the project root to download one."
+    )
+    st.stop()
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+def save_upload(f):
+    """Save an uploaded file as PNG for guaranteed compatibility with flux."""
+    d = (Path(__file__).parent / "uploads").resolve()
+    d.mkdir(exist_ok=True)
+    h = hashlib.sha256(f.getbuffer()).hexdigest()[:12]
+    p = d / f"{h}.png"
+    if not p.exists():
+        img = Image.open(f)
+        img.save(p, format="PNG")
+    return str(p)
+
+
+# ── Sidebar ───────────────────────────────────────────────────────────
+
+with st.sidebar:
+    st.header("Settings")
+
+    model = st.selectbox(
+        "Model",
+        models,
+        format_func=lambda m: m["label"],
+        help="The FLUX.2 model to use. Distilled is fast (4 steps), "
+             "base produces higher quality but is ~25x slower.",
+    )
+    is_distilled = model["distilled"]
+
+    st.divider()
+
+    mode = st.radio(
+        "Mode",
+        ["Text to Image", "Image to Image"],
+        help="**Text to Image** generates from a prompt alone.\n\n"
+             "**Image to Image** uses 1–16 reference images as visual context. "
+             "The model attends to every reference during generation via "
+             "in-context conditioning. One image works as a classic img2img; "
+             "multiple images let the model combine their elements.",
+    )
+
+    st.divider()
+    st.subheader("Dimensions")
+    c1, c2 = st.columns(2)
+    width = c1.number_input(
+        "Width", 64, 1792, 256, 16,
+        help="Output width in pixels. Must be a multiple of 16. Max 1792.",
+    )
+    height = c2.number_input(
+        "Height", 64, 1792, 256, 16,
+        help="Output height in pixels. Must be a multiple of 16. Max 1792.",
+    )
+
+    st.divider()
+    st.subheader("Sampling")
+
+    steps = st.number_input(
+        "Steps", 1, 256, 4 if is_distilled else 50,
+        help="Number of denoising iterations. "
+             "Distilled: 4 is the trained sweet spot. "
+             "Base: 50 for max quality, 10 for a quick preview.",
+    )
+    seed = st.number_input(
+        "Seed", -1, 2**31, -1,
+        help="Reproducibility seed. Use -1 for a random seed each time. "
+             "The same seed with the same settings produces the same image.",
+    )
+    guidance = st.number_input(
+        "Guidance", 0.0, 100.0, 1.0 if is_distilled else 4.0, 0.5,
+        help="Classifier-Free Guidance strength. "
+             "Higher values follow the prompt more strictly. "
+             "Distilled default: 1.0, base default: 4.0.",
+    )
+
+    st.divider()
+    st.subheader("Schedule")
+
+    SCHEDULES = {
+        "Shifted sigmoid (default)": "sigmoid",
+        "Linear": "linear",
+        "Power curve": "power",
+    }
+    schedule_label = st.radio(
+        "Timestep distribution",
+        list(SCHEDULES.keys()),
+        help="Controls how denoising effort is distributed across steps.\n\n"
+             "**Shifted sigmoid** concentrates work in the high-noise phase "
+             "and matches the training distribution.\n\n"
+             "**Linear** spreads steps uniformly. Can improve base model results "
+             "at reduced step counts (e.g. 10 steps).\n\n"
+             "**Power curve** is a tunable middle ground between sigmoid and linear.",
+    )
+    schedule_val = SCHEDULES[schedule_label]
+
+    power_alpha = 2.0
+    if schedule_val == "power":
+        power_alpha = st.number_input(
+            "Power exponent", 0.1, 10.0, 2.0, 0.1,
+            help="Controls front-loading intensity. "
+                 "1.0 equals linear, higher values concentrate more steps early.",
+        )
+
+    with st.expander("Advanced"):
+        force_base = st.checkbox(
+            "Force base model mode",
+            help="Override autodetection. Enables Classifier-Free Guidance "
+                 "with two transformer passes per step.",
+        )
+        no_mmap = st.checkbox(
+            "Disable memory mapping",
+            help="Load all weights into RAM upfront. "
+                 "Uses ~16 GB but avoids per-step loading overhead on CPU/BLAS.",
+        )
+
+
+# ── Main: Generate ────────────────────────────────────────────────────
+
+st.title("FLUX.2 Image Generator")
+st.caption("Generate images with the FLUX.2 klein 4B model — pure C inference.")
+
+prompt = st.text_area(
+    "Prompt",
+    placeholder="Describe the image you want to generate...",
+    help="Be descriptive. For image-to-image, describe the desired output "
+         "rather than giving instructions (e.g. 'oil painting of a sunset' "
+         "instead of 'make it an oil painting').",
+)
+
+input_paths = []
+
+if mode == "Image to Image":
+    files = st.file_uploader(
+        "Reference images (up to 16)",
+        type=["png", "jpg", "jpeg", "ppm", "webp", "tiff", "bmp"],
+        accept_multiple_files=True,
+        help="Upload one or more reference images. Each is encoded separately and "
+             "the model attends to all of them during generation. "
+             "One image → classic img2img. Multiple → multi-reference combination.",
+    )
+    for f in (files or []):
+        input_paths.append(save_upload(f))
+    if input_paths:
+        cols = st.columns(min(len(input_paths), 4))
+        for i, p in enumerate(input_paths):
+            cols[i % 4].image(p, width=150, caption=f"Ref {i + 1}")
+
+ready = bool(prompt and prompt.strip())
+if mode == "Image to Image" and not input_paths:
+    ready = False
+
+if st.button("Generate", type="primary", disabled=not ready, use_container_width=True):
+    w = (width // 16) * 16
+    h = (height // 16) * 16
+    settings = {
+        "width": w, "height": h, "steps": steps,
+        "seed": seed, "guidance": guidance,
+        "schedule": schedule_val, "power_alpha": power_alpha,
+        "force_base": force_base, "no_mmap": no_mmap,
+    }
+    mode_key = "img2img" if input_paths else "txt2img"
+    task_id = store.create(mode_key, prompt.strip(), settings, model["path"], input_paths)
+    flux_runner.submit(task_id)
+    st.rerun()
+
+
+# ── Active Tasks ──────────────────────────────────────────────────────
+
+@st.fragment(run_every=2)
+def active_tasks_panel():
+    tasks = store.active()
+
+    prev_ids = st.session_state.get("_active_ids", set())
+    curr_ids = {t["id"] for t in tasks}
+    st.session_state["_active_ids"] = curr_ids
+
+    if prev_ids and not prev_ids.issubset(curr_ids):
+        st.rerun()
+
+    if not tasks:
+        return
+
+    st.subheader("Active Tasks")
+    for task in tasks:
+        with st.container(border=True):
+            left, right = st.columns([6, 1])
+            with left:
+                st.markdown(f"**{task['prompt'][:120]}**")
+                pct = min(task["progress"] / 100.0, 1.0)
+                st.progress(pct, text=task["phase"] or "Queued")
+                created = datetime.fromisoformat(task["created_at"])
+                elapsed = (datetime.now() - created).total_seconds()
+                st.caption(
+                    f"{task['width']}\u00d7{task['height']}  \u00b7  "
+                    f"{task['mode']}  \u00b7  {elapsed:.0f}s elapsed"
+                )
+            with right:
+                pid = task.get("pid")
+                if pid and st.button("Cancel", key=f"stop_{task['id']}"):
+                    try:
+                        os.kill(pid, signal.SIGTERM)
+                    except ProcessLookupError:
+                        pass
+                    store.fail(task["id"], "Cancelled by user")
+                    st.rerun()
+
+active_tasks_panel()
+
+
+# ── Gallery ───────────────────────────────────────────────────────────
+
+st.divider()
+st.subheader("Generated Images")
+
+all_tasks = store.history(100)
+completed = [
+    t for t in all_tasks
+    if t["status"] == "completed"
+    and t.get("output_path")
+    and Path(t["output_path"]).exists()
+]
+failed = [t for t in all_tasks if t["status"] == "failed"]
+
+if completed:
+    cols = st.columns(4)
+    for i, t in enumerate(completed):
+        with cols[i % 4]:
+            st.image(t["output_path"])
+            st.caption(t["prompt"][:60])
+            parts = [f"{t['width']}\u00d7{t['height']}"]
+            if t.get("elapsed"):
+                parts.append(f"{t['elapsed']:.1f}s")
+            if t.get("actual_seed") is not None:
+                parts.append(f"seed {t['actual_seed']}")
+            st.caption(" \u00b7 ".join(parts))
+
+            dl_col, rm_col = st.columns(2)
+            with open(t["output_path"], "rb") as img_file:
+                dl_col.download_button(
+                    "Save",
+                    img_file.read(),
+                    file_name=Path(t["output_path"]).name,
+                    mime="image/png",
+                    key=f"dl_{t['id']}",
+                )
+            if rm_col.button("Delete", key=f"rm_{t['id']}"):
+                store.delete(t["id"])
+                st.rerun()
+
+elif not all_tasks:
+    st.info("No images generated yet. Enter a prompt and click Generate.")
+
+if failed:
+    with st.expander(f"Failed tasks ({len(failed)})"):
+        for t in failed:
+            col_err, col_dismiss = st.columns([5, 1])
+            col_err.error(
+                f"**{t['prompt'][:80]}** \u2014 {t.get('error', 'Unknown error')}"
+            )
+            if col_dismiss.button("Dismiss", key=f"dismiss_{t['id']}"):
+                store.delete(t["id"])
+                st.rerun()

--- a/webui/flux_runner.py
+++ b/webui/flux_runner.py
@@ -1,0 +1,212 @@
+"""Background execution of the flux binary with real-time progress tracking."""
+
+import fcntl
+import json
+import os
+import re
+import select
+import subprocess
+import threading
+from pathlib import Path
+
+import store
+
+ROOT = Path(__file__).resolve().parent.parent
+BINARY = ROOT / "flux"
+
+
+def find_models():
+    """Scan the project root for directories containing model_index.json."""
+    models = []
+    for entry in ROOT.iterdir():
+        if not entry.is_dir():
+            continue
+        index = entry / "model_index.json"
+        if not index.exists():
+            continue
+        distilled = True
+        try:
+            with open(index) as f:
+                info = json.load(f)
+            distilled = info.get("is_distilled", False)
+        except Exception:
+            pass
+        tag = "distilled, fast" if distilled else "base, high quality"
+        models.append({
+            "path": str(entry),
+            "name": entry.name,
+            "distilled": distilled,
+            "label": f"{entry.name}  ({tag})",
+        })
+    return sorted(models, key=lambda m: m["name"])
+
+
+_lock = threading.Lock()
+_workers = {}
+
+
+def submit(task_id):
+    """Launch a background thread to run flux for the given task."""
+    t = threading.Thread(target=_run, args=(task_id,), daemon=True)
+    with _lock:
+        _workers[task_id] = t
+    t.start()
+
+
+def _build_cmd(task):
+    cmd = [
+        str(BINARY),
+        "-d", task["model_dir"],
+        "-p", task["prompt"],
+        "-o", task["output_path"],
+        "-W", str(task["width"]),
+        "-H", str(task["height"]),
+        "-s", str(task["steps"]),
+        "-S", str(task["seed"]),
+        "-g", str(task["guidance"]),
+    ]
+    if task["schedule"] == "linear":
+        cmd.append("--linear")
+    elif task["schedule"] == "power":
+        cmd += ["--power", "--power-alpha", str(task["power_alpha"])]
+    if task["force_base"]:
+        cmd.append("--base")
+    if task["no_mmap"]:
+        cmd.append("--no-mmap")
+    for p in json.loads(task.get("input_paths", "[]")):
+        cmd += ["-i", p]
+    return cmd
+
+
+def _run(task_id):
+    task = store.get(task_id)
+    if not task:
+        return
+
+    store.update_progress(task_id, 1, "Starting")
+
+    try:
+        proc = subprocess.Popen(
+            _build_cmd(task),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        store.set_pid(task_id, proc.pid)
+
+        mon = _Monitor(task_id)
+        fd = proc.stderr.fileno()
+        flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+        fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+        while proc.poll() is None:
+            if select.select([fd], [], [], 0.5)[0]:
+                try:
+                    chunk = os.read(fd, 4096)
+                    if chunk:
+                        mon.feed(chunk.decode("utf-8", errors="replace"))
+                except OSError:
+                    break
+
+        fcntl.fcntl(fd, fcntl.F_SETFL, flags)
+        rest = proc.stderr.read()
+        if rest:
+            mon.feed(rest.decode("utf-8", errors="replace"))
+
+        if proc.returncode == 0 and Path(task["output_path"]).exists():
+            store.complete(task_id, mon.seed, mon.elapsed)
+        else:
+            store.fail(task_id, mon.error or f"Process exited with code {proc.returncode}")
+
+    except Exception as e:
+        store.fail(task_id, str(e))
+    finally:
+        with _lock:
+            _workers.pop(task_id, None)
+
+
+class _Monitor:
+    """Parse flux stderr output to extract progress percentages.
+
+    Progress mapping:
+      0-5%    Loading model
+      5-20%   Text encoding
+      20-90%  Denoising steps (proportional)
+      90-97%  VAE decode
+      97-100% Saving
+    """
+
+    def __init__(self, task_id):
+        self.task_id = task_id
+        self.buf = ""
+        self.seed = None
+        self.elapsed = None
+        self.error = None
+        self._step = 0
+
+    def feed(self, text):
+        self.buf += text
+        while "\n" in self.buf:
+            line, self.buf = self.buf.split("\n", 1)
+            self._line(line.strip())
+        if self.buf:
+            self._check_step(self.buf)
+
+    def _line(self, s):
+        if not s:
+            return
+
+        m = re.match(r"Seed:\s*(\d+)", s)
+        if m:
+            self.seed = int(m.group(1))
+            store.update_progress(self.task_id, 3, "Initialized")
+            return
+
+        if "Loading VAE" in s:
+            store.update_progress(self.task_id, 5, "Loading model")
+            return
+
+        if "Loading" in s and "input" in s:
+            store.update_progress(self.task_id, 8, "Loading references")
+            return
+
+        if "Encoding text" in s or "encoding text" in s:
+            if "done" in s:
+                store.update_progress(self.task_id, 20, "Text encoded")
+            else:
+                store.update_progress(self.task_id, 10, "Encoding text")
+            return
+
+        if self._check_step(s):
+            return
+
+        if ("Decoding" in s or "decoding" in s) and "Encoding" not in s:
+            if "done" in s:
+                store.update_progress(self.task_id, 95, "Decoded")
+            else:
+                store.update_progress(self.task_id, 90, "Decoding image")
+            return
+
+        if s.startswith("Saving"):
+            store.update_progress(self.task_id, 97, "Saving")
+            return
+
+        m = re.search(r"Total generation time:\s*([\d.]+)", s)
+        if m:
+            self.elapsed = float(m.group(1))
+            return
+
+        if re.search(r"[Ee]rror:", s):
+            self.error = s
+
+    def _check_step(self, s):
+        m = re.search(r"Step\s+(\d+)/(\d+)", s)
+        if not m:
+            return False
+        step, total = int(m.group(1)), int(m.group(2))
+        if step != self._step:
+            self._step = step
+            pct = 20 + (step / total) * 70
+            store.update_progress(
+                self.task_id, pct, f"Denoising step {step}/{total}"
+            )
+        return True

--- a/webui/requirements.txt
+++ b/webui/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.37.0
+Pillow>=10.0.0

--- a/webui/store.py
+++ b/webui/store.py
@@ -1,0 +1,175 @@
+"""SQLite-backed task persistence for flux generation jobs."""
+
+import json
+import os
+import sqlite3
+import uuid
+from datetime import datetime
+from pathlib import Path
+
+DB = Path(__file__).parent / "data" / "tasks.db"
+
+
+def _conn():
+    DB.parent.mkdir(exist_ok=True)
+    c = sqlite3.connect(str(DB), timeout=10)
+    c.row_factory = sqlite3.Row
+    c.execute("PRAGMA journal_mode=WAL")
+    c.execute("PRAGMA busy_timeout=5000")
+    return c
+
+
+def init():
+    c = _conn()
+    c.execute("""CREATE TABLE IF NOT EXISTS tasks (
+        id            TEXT PRIMARY KEY,
+        mode          TEXT NOT NULL,
+        prompt        TEXT NOT NULL,
+        width         INTEGER NOT NULL,
+        height        INTEGER NOT NULL,
+        steps         INTEGER NOT NULL,
+        seed          INTEGER NOT NULL,
+        guidance      REAL NOT NULL,
+        schedule      TEXT DEFAULT 'sigmoid',
+        power_alpha   REAL DEFAULT 2.0,
+        force_base    INTEGER DEFAULT 0,
+        no_mmap       INTEGER DEFAULT 0,
+        input_paths   TEXT DEFAULT '[]',
+        model_dir     TEXT NOT NULL,
+        output_path   TEXT,
+        status        TEXT DEFAULT 'pending',
+        progress      REAL DEFAULT 0,
+        phase         TEXT DEFAULT '',
+        created_at    TEXT NOT NULL,
+        started_at    TEXT,
+        completed_at  TEXT,
+        elapsed       REAL,
+        error         TEXT,
+        actual_seed   INTEGER,
+        pid           INTEGER
+    )""")
+    rows = c.execute(
+        "SELECT id, pid FROM tasks WHERE status IN ('pending','running')"
+    ).fetchall()
+    for row in rows:
+        pid = row[1]
+        alive = False
+        if pid:
+            try:
+                os.kill(pid, 0)
+                alive = True
+            except (ProcessLookupError, PermissionError, OSError):
+                pass
+        if not alive:
+            c.execute(
+                "UPDATE tasks SET status='failed', "
+                "error='Process terminated (server restart or crash)' "
+                "WHERE id=?",
+                (row[0],),
+            )
+    c.commit()
+    c.close()
+
+
+def create(mode, prompt, settings, model_dir, input_paths=None):
+    task_id = uuid.uuid4().hex[:12]
+    out_dir = (Path(__file__).parent / "outputs").resolve()
+    out_dir.mkdir(exist_ok=True)
+    output_path = str(out_dir / f"{task_id}.png")
+    c = _conn()
+    c.execute(
+        "INSERT INTO tasks "
+        "(id,mode,prompt,width,height,steps,seed,guidance,"
+        "schedule,power_alpha,force_base,no_mmap,"
+        "model_dir,input_paths,output_path,created_at) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (task_id, mode, prompt,
+         settings["width"], settings["height"],
+         settings["steps"], settings["seed"],
+         settings["guidance"], settings["schedule"],
+         settings["power_alpha"],
+         int(settings.get("force_base", False)),
+         int(settings.get("no_mmap", False)),
+         model_dir, json.dumps(input_paths or []),
+         output_path, datetime.now().isoformat()),
+    )
+    c.commit()
+    c.close()
+    return task_id
+
+
+def update_progress(task_id, progress, phase=""):
+    c = _conn()
+    c.execute(
+        "UPDATE tasks SET progress=?, phase=?, status='running', "
+        "started_at=COALESCE(started_at,?) WHERE id=?",
+        (progress, phase, datetime.now().isoformat(), task_id),
+    )
+    c.commit()
+    c.close()
+
+
+def complete(task_id, actual_seed=None, elapsed=None):
+    c = _conn()
+    c.execute(
+        "UPDATE tasks SET status='completed', progress=100, phase='Done', "
+        "completed_at=?, actual_seed=?, elapsed=? WHERE id=?",
+        (datetime.now().isoformat(), actual_seed, elapsed, task_id),
+    )
+    c.commit()
+    c.close()
+
+
+def fail(task_id, error):
+    c = _conn()
+    c.execute(
+        "UPDATE tasks SET status='failed', phase='', error=?, completed_at=? WHERE id=?",
+        (error, datetime.now().isoformat(), task_id),
+    )
+    c.commit()
+    c.close()
+
+
+def set_pid(task_id, pid):
+    c = _conn()
+    c.execute("UPDATE tasks SET pid=? WHERE id=?", (pid, task_id))
+    c.commit()
+    c.close()
+
+
+def get(task_id):
+    c = _conn()
+    row = c.execute("SELECT * FROM tasks WHERE id=?", (task_id,)).fetchone()
+    c.close()
+    return dict(row) if row else None
+
+
+def active():
+    c = _conn()
+    rows = c.execute(
+        "SELECT * FROM tasks WHERE status IN ('pending','running') "
+        "ORDER BY created_at"
+    ).fetchall()
+    c.close()
+    return [dict(r) for r in rows]
+
+
+def history(limit=50):
+    c = _conn()
+    rows = c.execute(
+        "SELECT * FROM tasks ORDER BY created_at DESC LIMIT ?", (limit,)
+    ).fetchall()
+    c.close()
+    return [dict(r) for r in rows]
+
+
+def delete(task_id):
+    task = get(task_id)
+    if task and task.get("output_path"):
+        p = Path(task["output_path"])
+        if p.exists():
+            p.unlink()
+    c = _conn()
+    c.execute("DELETE FROM tasks WHERE id=?", (task_id,))
+    c.commit()
+    c.close()


### PR DESCRIPTION
**Add Streamlit Web UI**
Browser-based interface for flux image generation. Exposes all CLI options in a clean UI with persistent task tracking.
**Features**

- All generation modes — text-to-image and image-to-image with up to 16 reference images
- Every CLI option — dimensions, steps, seed, guidance, timestep schedule (sigmoid / linear / power curve), force-base, no-mmap
- Real-time progress — live progress bar parsing flux's stderr output (loading → encoding → denoising steps → decode → save)
- Task persistence — SQLite-backed, survives page reloads and server restarts. Orphaned tasks are detected and cleaned up automatically
- Cancel running tasks — sends SIGTERM to the flux process from the UI
- Image gallery — browse completed generations with prompt, dimensions, timing, and seed. Download or delete directly
- Format-agnostic uploads — any image format is converted to PNG via Pillow before passing to flux, avoiding custom JPEG decoder edge cases

**Architecture**
Fully contained in webui/, does not modify any existing files. Three Python modules

**Setup**
```
cd webui
python3 -m venv .venv
source .venv/bin/activate
pip install -r requirements.txt
streamlit run app.py
```