### PR TITLE
Fix two crash bugs: 16-bit PNG and GPU VAE decode

### DIFF
--- a/flux_vae.c
+++ b/flux_vae.c
@@ -508,6 +508,11 @@ static flux_image *vae_decode_gpu(flux_vae_t *vae, const float *latent,
 
     int ch_mult[4] = {1, 2, 4, 4};
 
+    /* Ensure work buffers are allocated (needed for CPU portions of GPU path) */
+    int out_H = latent_h * 16;
+    int out_W = latent_w * 16;
+    if (vae_ensure_work_buffers(vae, out_H, out_W) < 0) return NULL;
+
     /* Batch denormalize + unpatchify on CPU (small data, fast) */
     float *cpu_x = vae->work1;
     float *cpu_work = vae->work2;


### PR DESCRIPTION
## Summary

Two crash fixes for the C binary:

- **PNG loader crash on 16-bit images**: `load_png()` ignores the `bit_depth` and `interlace` IHDR fields, assuming all PNGs are 8-bit non-interlaced. 16-bit PNGs (common from Midjourney, Photoshop, etc.) have 2 bytes per channel but the loader allocates buffers for 1 byte per channel, causing a buffer overflow and crash. Fix: read and validate both fields, reject unsupported formats with an error message.

- **GPU VAE decode segfault**: `vae_decode_gpu()` uses `vae->work1` and `vae->work2` for CPU portions (denormalization, attention sync) but never calls `vae_ensure_work_buffers()`, so the buffers are NULL on the first decode call. Fix: allocate work buffers at the start of the function.

## Changes

- `flux_image.c`: Parse `bit_depth` and `interlace` from IHDR, reject non-8-bit or interlaced PNGs with `fprintf(stderr, ...)` + return NULL
- `flux_vae.c`: Add `vae_ensure_work_buffers()` call at the top of `vae_decode_gpu()`

## Test plan

- [x] Verified 16-bit PNG now returns NULL with error message instead of crashing
- [x] Verified GPU VAE decode works correctly after fix
- [x] `make test` passes (64x64, 512x512, img2img reference tests all pass)
- [x] No regressions on standard 8-bit PNG loading