### PR TITLE
Fix two MPS GPU attention bugs causing NaN/black image output

### DIFF
--- a/iris_metal.m
+++ b/iris_metal.m
@@ -2878,6 +2878,13 @@ int iris_gpu_attention_mps_bf16(iris_gpu_tensor_t out,
         id<MTLBuffer> bufScores = pool_get_buffer(scores_size);
         if (!bufScores) return 0;
 
+        /* Zero the scores buffer before use. Pool buffers may be reused from a
+         * previous operation that wrote differently-typed data; those bytes
+         * interpreted as f16 can produce NaN bit patterns. MPSMatrixMultiplication
+         * with beta=0.0f still evaluates 0*NaN=NaN in IEEE 754, so the output
+         * would inherit NaN from the stale buffer. Zeroing ensures a clean start. */
+        memset([bufScores contents], 0, scores_size);
+
         id<MTLCommandBuffer> cmdBuffer = get_tensor_cmd();
 
         /* === Phase 1: Q @ K^T for each head === */

--- a/iris_transformer_flux.c
+++ b/iris_transformer_flux.c
@@ -2390,7 +2390,6 @@ static int single_block_forward_gpu(float *hidden, const single_block_t *block,
 
     /* Allocate output tensors */
     iris_gpu_tensor_t norm_gpu = iris_gpu_tensor_alloc(seq * h_size);
-    iris_gpu_tensor_t fused_gpu = iris_gpu_tensor_alloc(seq * fused_dim);
     iris_gpu_tensor_t q_gpu = iris_gpu_tensor_alloc(seq * h_size);
     iris_gpu_tensor_t k_gpu = iris_gpu_tensor_alloc(seq * h_size);
     iris_gpu_tensor_t v_gpu = iris_gpu_tensor_alloc(seq * h_size);
@@ -2400,12 +2399,11 @@ static int single_block_forward_gpu(float *hidden, const single_block_t *block,
     iris_gpu_tensor_t concat_gpu = iris_gpu_tensor_alloc(seq * (h_size + mlp_hidden));
     iris_gpu_tensor_t proj_out_gpu = iris_gpu_tensor_alloc(seq * h_size);
 
-    if (!norm_gpu || !fused_gpu || !q_gpu || !k_gpu || !v_gpu ||
+    if (!norm_gpu || !q_gpu || !k_gpu || !v_gpu ||
         !gate_gpu || !up_gpu || !attn_out_gpu || !concat_gpu || !proj_out_gpu) {
         /* Cleanup and fall back */
         if (hidden_gpu) iris_gpu_tensor_free(hidden_gpu);
         if (norm_gpu) iris_gpu_tensor_free(norm_gpu);
-        if (fused_gpu) iris_gpu_tensor_free(fused_gpu);
         if (q_gpu) iris_gpu_tensor_free(q_gpu);
         if (k_gpu) iris_gpu_tensor_free(k_gpu);
         if (v_gpu) iris_gpu_tensor_free(v_gpu);
@@ -2429,7 +2427,6 @@ static int single_block_forward_gpu(float *hidden, const single_block_t *block,
         /* Cleanup and fall back */
         iris_gpu_tensor_free(hidden_gpu);
         iris_gpu_tensor_free(norm_gpu);
-        iris_gpu_tensor_free(fused_gpu);
         iris_gpu_tensor_free(q_gpu);
         iris_gpu_tensor_free(k_gpu);
         iris_gpu_tensor_free(v_gpu);


### PR DESCRIPTION
## Summary

Two bugs in the MPS (Metal Performance Shaders) GPU path were found and reproduced while testing generation at 512×512 resolution, where GPU buffer pool pressure is highest.

### Bug 1: Dead `fused_gpu` pool allocation in `single_block_forward_gpu` (`iris_transformer_flux.c`)

`iris_gpu_tensor_t fused_gpu = iris_gpu_tensor_alloc(seq * fused_dim)` is allocated before the fused QKV+MLP linear computation, but the result is always written into `fused_result` (the return value of `iris_gpu_linear_bf16`). The pre-allocated `fused_gpu` is:
- Never written to or used in any computation
- Never freed in the normal success path (only in early error paths)

This leaks one GPU pool slot per single block — 20 slots per denoising step — exhausting the pool for large images.

**Fix:** Remove the unused allocation and all references to it.

### Bug 2: `bufScores` not zero-initialized in `iris_gpu_attention_mps_bf16` (`iris_metal.m`)

`pool_get_buffer(scores_size)` returns a Metal buffer from the pool that may have been previously used by a different operation writing different data types (e.g. f32 output). When those f32 bit patterns are reinterpreted as f16, many values are NaN.

`MPSMatrixMultiplication` with `beta=0.0f` does **not** special-case beta=0 to skip reading the old buffer — it evaluates `beta * C_old` in IEEE 754 arithmetic, and `0.0f * NaN = NaN`. The NaN propagates through the attention computation and produces all-black output.

**Fix:** `memset` the scores buffer to zero immediately after `pool_get_buffer`, before any MPS operations use it.

## Test plan

- [ ] Build with `make mps` — compiles cleanly
- [ ] Standard generation at 64×64 (pool not stressed) — correct output
- [ ] Generation at 512×512 — previously produced all-black images due to Bug 2; should now produce correct output

🤖 Generated with [Claude Code](https://claude.com/claude-code)