### PR TITLE
fix(mps/mmap): clear f16 weight cache between single blocks

### DIFF
--- a/iris_transformer_flux.c
+++ b/iris_transformer_flux.c
@@ -2355,6 +2355,12 @@ static int single_block_forward_gpu(float *hidden, const single_block_t *block,
     if (!iris_metal_available() || !iris_metal_shaders_available()) return 0;
     if (block->qkv_mlp_weight_bf16 == NULL) return 0;  /* Need bf16 weights */
 
+    /* In mmap mode, the OS may reuse the same virtual address for different blocks'
+     * weights after munmap. The f16 weight cache is keyed by CPU pointer, so it
+     * would return a stale Metal buffer for the new block. Clear it to avoid wrong
+     * outputs in multi-step denoising when --mmap is used. */
+    if (tf->use_mmap) iris_metal_clear_f16_cache_only();
+
     int h_size = tf->hidden_size;
     int heads = tf->num_heads;
     int head_dim = tf->head_dim;


### PR DESCRIPTION
## Problem

In `--mmap` mode, block weights are unmapped after use to reclaim memory. When the next block is loaded, the OS can reuse the same virtual address range. The f16 weight cache in `iris_metal.m` is keyed by CPU pointer, so it returns the stale Metal buffer from the previous block at that address — producing wrong outputs in multi-step denoising.

## Fix

`iris_metal_clear_f16_cache_only()` already exists for exactly this purpose (called in the bf16 path's `warmup_bf16_weights`), but was never called in `single_block_forward_gpu`. This PR adds the call, guarded by `tf->use_mmap`.

```c
/* In mmap mode, the OS may reuse the same virtual address for different blocks'
 * weights after munmap. The f16 weight cache is keyed by CPU pointer, so it
 * would return a stale Metal buffer for the new block. */
if (tf->use_mmap) iris_metal_clear_f16_cache_only();
```

## Impact

This is a correctness bug: without the fix, the GPU path silently uses wrong weights for all single blocks after the first in mmap+MPS mode, affecting every denoising step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)