### PR TITLE
Add FLUX.2-dev support with Mistral text encoder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
 # Source files
-SRCS = iris.c iris_kernels.c iris_tokenizer.c iris_vae.c iris_transformer_flux.c iris_transformer_zimage.c iris_sample.c iris_image.c jpeg.c iris_safetensors.c iris_qwen3.c iris_qwen3_tokenizer.c terminals.c
+SRCS = iris.c iris_kernels.c iris_tokenizer.c iris_vae.c iris_transformer_flux.c iris_transformer_zimage.c iris_sample.c iris_image.c jpeg.c iris_safetensors.c iris_qwen3.c iris_qwen3_tokenizer.c iris_mistral.c iris_mistral_tokenizer.c terminals.c
 OBJS = $(SRCS:.c=.o)
 CLI_SRCS = iris_cli.c linenoise.c embcache.c
 CLI_OBJS = $(CLI_SRCS:.c=.o)
@@ -176,7 +176,7 @@ endif
 # =============================================================================
 # Dependencies
 # =============================================================================
-iris.o: iris.c iris.h iris_kernels.h iris_safetensors.h iris_qwen3.h
+iris.o: iris.c iris.h iris_kernels.h iris_safetensors.h iris_qwen3.h iris_mistral.h
 iris_kernels.o: iris_kernels.c iris_kernels.h
 iris_tokenizer.o: iris_tokenizer.c iris.h
 iris_vae.o: iris_vae.c iris.h iris_kernels.h
@@ -187,6 +187,8 @@ iris_image.o: iris_image.c iris.h
 iris_safetensors.o: iris_safetensors.c iris_safetensors.h
 iris_qwen3.o: iris_qwen3.c iris_qwen3.h iris_safetensors.h
 iris_qwen3_tokenizer.o: iris_qwen3_tokenizer.c iris_qwen3.h
+iris_mistral.o: iris_mistral.c iris_mistral.h iris_safetensors.h iris_kernels.h
+iris_mistral_tokenizer.o: iris_mistral_tokenizer.c iris_mistral.h
 terminals.o: terminals.c terminals.h iris.h
 iris_cli.o: iris_cli.c iris_cli.h iris.h iris_qwen3.h embcache.h linenoise.h terminals.h
 linenoise.o: linenoise.c linenoise.h

--- a/iris_metal.h
+++ b/iris_metal.h
@@ -447,6 +447,10 @@ void iris_gpu_add_bf16(iris_gpu_tensor_t out, iris_gpu_tensor_t a, iris_gpu_tens
 /* BF16 buffer copy (GPU blit): dst = src */
 void iris_gpu_copy_bf16(iris_gpu_tensor_t dst, iris_gpu_tensor_t src, size_t n);
 
+/* BF16 region copy (GPU blit): copy n elements from src[src_offset..] to dst[dst_offset..] */
+void iris_gpu_copy_region_bf16(iris_gpu_tensor_t dst, iris_gpu_tensor_t src,
+                                size_t n, size_t dst_offset, size_t src_offset);
+
 /* BF16 SiLU multiply: gate = silu(gate) * up */
 void iris_gpu_silu_mul_bf16(iris_gpu_tensor_t gate, iris_gpu_tensor_t up, int n);
 
@@ -746,6 +750,12 @@ void iris_metal_warmup_bf16_buffer(const uint16_t *bf16_weights, size_t num_elem
  * Check if bf16 pipeline is available (all required shaders loaded).
  */
 int iris_bf16_pipeline_available(void);
+
+/*
+ * Check if hardware has native BF16 ALUs (M3+ / Apple9 family).
+ * On M1/M2, BF16 shaders compile but run emulated via F32 conversion.
+ */
+int iris_metal_has_native_bf16(void);
 
 #ifdef __OBJC__
 #import <Metal/Metal.h>

--- a/iris_mistral.c
+++ b/iris_mistral.c
@@ -1,0 +1,1222 @@
+/*
+ * Mistral-Small-3.2-24B Text Encoder Implementation
+ *
+ * Implements Mistral encoder for FLUX.2-dev text encoding.
+ * Architecture nearly identical to Qwen3 (GQA, SwiGLU, RoPE, RMSNorm).
+ *
+ * Key differences from Qwen3:
+ * - No Q/K per-head RMS normalization
+ * - Different extraction layers (10, 20, 30)
+ * - Different RMS norm epsilon (1e-5 vs 1e-6)
+ * - Always mmap mode (model is ~48GB)
+ * - Pooled embedding output (last real token hidden state)
+ *
+ * Forked from iris_qwen3.c.
+ */
+
+#include "iris_mistral.h"
+#include "iris_safetensors.h"
+#include "iris_kernels.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#ifdef USE_BLAS
+#ifdef __APPLE__
+#include <Accelerate/Accelerate.h>
+#else
+#include <cblas.h>
+#endif
+#endif
+
+#ifdef USE_METAL
+#include "iris_metal.h"
+#endif
+
+/* GPU acceleration threshold (same as Qwen3) */
+#define MISTRAL_MIN_GPU_ELEMENTS (10 * 1024 * 1024)
+
+/* Maximum safetensors shards */
+#define MISTRAL_MAX_SHARDS 32
+
+/* ========================================================================
+ * Data Structures
+ * ======================================================================== */
+
+typedef struct {
+    float *q_proj_weight;      /* [num_heads * head_dim, hidden] */
+    float *k_proj_weight;      /* [num_kv_heads * head_dim, hidden] */
+    float *v_proj_weight;      /* [num_kv_heads * head_dim, hidden] */
+    float *o_proj_weight;      /* [hidden, num_heads * head_dim] */
+    /* NO q_norm / k_norm — Mistral doesn't use per-head QK normalization */
+    uint16_t *q_proj_weight_bf16;
+    uint16_t *k_proj_weight_bf16;
+    uint16_t *v_proj_weight_bf16;
+    uint16_t *o_proj_weight_bf16;
+} mistral_attention_t;
+
+typedef struct {
+    float *gate_proj_weight;   /* [intermediate, hidden] */
+    float *up_proj_weight;     /* [intermediate, hidden] */
+    float *down_proj_weight;   /* [hidden, intermediate] */
+    uint16_t *gate_proj_weight_bf16;
+    uint16_t *up_proj_weight_bf16;
+    uint16_t *down_proj_weight_bf16;
+} mistral_mlp_t;
+
+typedef struct {
+    float *input_layernorm_weight;
+    float *post_attention_layernorm_weight;
+    mistral_attention_t attn;
+    mistral_mlp_t mlp;
+} mistral_layer_t;
+
+struct mistral_model {
+    /* Architecture (from config.json) */
+    int hidden_size;
+    int intermediate_size;
+    int num_heads;
+    int num_kv_heads;
+    int head_dim;
+    int vocab_size;
+    float rope_theta;
+    int text_dim;          /* 3 * hidden_size */
+    int num_layers;
+
+    /* Embedding layer */
+    float *embed_tokens;   /* [vocab_size, hidden] */
+
+    /* Transformer layers */
+    mistral_layer_t *layers;
+
+    /* Final layer norm */
+    float *norm_weight;    /* [hidden] */
+
+    /* RoPE precomputed */
+    float *rope_cos;       /* [max_seq_len, head_dim/2] */
+    float *rope_sin;       /* [max_seq_len, head_dim/2] */
+
+    /* Working memory */
+    float *hidden_state;
+    float *residual;
+    float *q_buf, *k_buf, *v_buf;
+    float *attn_scores;
+    float *attn_out;
+    float *mlp_gate, *mlp_up, *mlp_out;
+    float *norm_buf;
+    float *attn_q_head, *attn_v_head, *attn_out_head;
+
+    /* Output layer storage */
+    float *layer_outputs[3];
+
+    /* Pooled embedding (last real token hidden state) */
+    float *pooled_output;
+    int pooled_seq_idx;    /* Index of last real token */
+
+    /* Mmap mode */
+    int use_mmap;
+    safetensors_file_t *sf_files[MISTRAL_MAX_SHARDS];
+    int num_sf_files;
+
+    /* BF16 GPU acceleration */
+    int use_bf16;
+};
+
+/* Forward declarations for mmap streaming */
+static int mistral_load_layer_weights(mistral_layer_t *layer, safetensors_file_t **files,
+                                       int num_files, int layer_idx);
+#ifdef USE_METAL
+static int mistral_load_layer_small_f32(mistral_layer_t *layer, safetensors_file_t **files,
+                                         int num_files, int layer_idx);
+static int mistral_load_layer_bf16(mistral_layer_t *layer, safetensors_file_t **files,
+                                    int num_files, int layer_idx);
+#endif
+static void mistral_free_layer_weights(mistral_layer_t *layer);
+
+/* ========================================================================
+ * Basic Operations
+ * ======================================================================== */
+
+static void mistral_linear(float *y, const float *x, const float *W,
+                            int seq_len, int in_dim, int out_dim) {
+#ifdef USE_METAL
+    size_t matrix_elements = (size_t)seq_len * out_dim;
+    if (iris_metal_available() && matrix_elements >= MISTRAL_MIN_GPU_ELEMENTS) {
+        iris_metal_sgemm_cached(0, 1, seq_len, out_dim, in_dim,
+                                1.0f, x, in_dim, W, in_dim,
+                                0.0f, y, out_dim);
+        return;
+    }
+#endif
+#ifdef USE_BLAS
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                seq_len, out_dim, in_dim,
+                1.0f, x, in_dim, W, in_dim,
+                0.0f, y, out_dim);
+#else
+    for (int s = 0; s < seq_len; s++) {
+        for (int o = 0; o < out_dim; o++) {
+            float sum = 0.0f;
+            for (int i = 0; i < in_dim; i++) {
+                sum += x[s * in_dim + i] * W[o * in_dim + i];
+            }
+            y[s * out_dim + o] = sum;
+        }
+    }
+#endif
+}
+
+static void mistral_rms_norm(float *out, const float *x, const float *weight,
+                              int seq_len, int hidden, float eps) {
+    for (int s = 0; s < seq_len; s++) {
+        const float *x_row = x + s * hidden;
+        float *out_row = out + s * hidden;
+
+        float sum_sq = 0.0f;
+        for (int i = 0; i < hidden; i++) {
+            sum_sq += x_row[i] * x_row[i];
+        }
+        float rms = sqrtf(sum_sq / hidden + eps);
+        float rms_inv = 1.0f / rms;
+
+        for (int i = 0; i < hidden; i++) {
+            out_row[i] = x_row[i] * rms_inv * weight[i];
+        }
+    }
+}
+
+static void mistral_softmax(float *x, int len) {
+    float max_val = x[0];
+    for (int i = 1; i < len; i++) {
+        if (x[i] > max_val) max_val = x[i];
+    }
+
+    float sum = 0.0f;
+    for (int i = 0; i < len; i++) {
+        x[i] = fast_expf(x[i] - max_val);
+        sum += x[i];
+    }
+
+    float inv_sum = 1.0f / sum;
+    for (int i = 0; i < len; i++) {
+        x[i] *= inv_sum;
+    }
+}
+
+/* ========================================================================
+ * RoPE
+ * ======================================================================== */
+
+static void mistral_compute_rope_freqs(float *cos_out, float *sin_out,
+                                         int max_seq_len, int head_dim, float theta) {
+    int half_dim = head_dim / 2;
+    for (int pos = 0; pos < max_seq_len; pos++) {
+        for (int i = 0; i < half_dim; i++) {
+            float freq = 1.0f / powf(theta, (float)(2 * i) / head_dim);
+            float angle = pos * freq;
+            cos_out[pos * half_dim + i] = cosf(angle);
+            sin_out[pos * half_dim + i] = sinf(angle);
+        }
+    }
+}
+
+static void mistral_apply_rope(float *q, float *k, const float *cos_cache, const float *sin_cache,
+                                int seq_len, int num_q_heads, int num_kv_heads, int head_dim) {
+    int half_dim = head_dim / 2;
+
+    for (int s = 0; s < seq_len; s++) {
+        const float *cos_row = cos_cache + s * half_dim;
+        const float *sin_row = sin_cache + s * half_dim;
+
+        for (int h = 0; h < num_q_heads; h++) {
+            float *q_head = q + s * num_q_heads * head_dim + h * head_dim;
+            for (int i = 0; i < half_dim; i++) {
+                float x0 = q_head[i];
+                float x1 = q_head[i + half_dim];
+                q_head[i] = x0 * cos_row[i] - x1 * sin_row[i];
+                q_head[i + half_dim] = x0 * sin_row[i] + x1 * cos_row[i];
+            }
+        }
+
+        for (int h = 0; h < num_kv_heads; h++) {
+            float *k_head = k + s * num_kv_heads * head_dim + h * head_dim;
+            for (int i = 0; i < half_dim; i++) {
+                float x0 = k_head[i];
+                float x1 = k_head[i + half_dim];
+                k_head[i] = x0 * cos_row[i] - x1 * sin_row[i];
+                k_head[i + half_dim] = x0 * sin_row[i] + x1 * cos_row[i];
+            }
+        }
+    }
+}
+
+/* ========================================================================
+ * Attention (CPU Path)
+ * ======================================================================== */
+
+static void mistral_attention_forward(mistral_model_t *model, mistral_layer_t *layer,
+                                       int seq_len, const int *attention_mask) {
+    int num_heads = model->num_heads;
+    int num_kv_heads = model->num_kv_heads;
+    int head_dim = model->head_dim;
+    int hidden = model->hidden_size;
+    int kv_dim = num_kv_heads * head_dim;
+    int q_dim = num_heads * head_dim;
+    float scale = 1.0f / sqrtf((float)head_dim);
+
+    /* Q, K, V projections */
+    mistral_linear(model->q_buf, model->norm_buf, layer->attn.q_proj_weight,
+                   seq_len, hidden, q_dim);
+    mistral_linear(model->k_buf, model->norm_buf, layer->attn.k_proj_weight,
+                   seq_len, hidden, kv_dim);
+    mistral_linear(model->v_buf, model->norm_buf, layer->attn.v_proj_weight,
+                   seq_len, hidden, kv_dim);
+
+    /* NO Q/K RMS norm — Mistral skips this step */
+
+    /* Apply RoPE */
+    mistral_apply_rope(model->q_buf, model->k_buf, model->rope_cos, model->rope_sin,
+                       seq_len, num_heads, num_kv_heads, head_dim);
+
+#ifdef USE_METAL
+    if (iris_metal_available()) {
+        if (iris_metal_causal_attention(model->attn_out,
+                                         model->q_buf, model->k_buf, model->v_buf,
+                                         attention_mask,
+                                         seq_len, num_heads, num_kv_heads,
+                                         head_dim, scale)) {
+            goto output_proj;
+        }
+    }
+#endif
+
+    /* CPU fallback: GQA attention */
+    {
+        int heads_per_kv = num_heads / num_kv_heads;
+
+        for (int h = 0; h < num_heads; h++) {
+            int kv_h = h / heads_per_kv;
+            float *scores = model->attn_scores + h * seq_len * seq_len;
+
+            const float *q_strided = model->q_buf + h * head_dim;
+            const float *k_strided = model->k_buf + kv_h * head_dim;
+
+#ifdef USE_BLAS
+            cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                        seq_len, seq_len, head_dim,
+                        scale, q_strided, q_dim, k_strided, kv_dim,
+                        0.0f, scores, seq_len);
+#else
+            for (int i = 0; i < seq_len; i++) {
+                for (int j = 0; j < seq_len; j++) {
+                    float dot = 0.0f;
+                    for (int d = 0; d < head_dim; d++) {
+                        dot += q_strided[i * q_dim + d] * k_strided[j * kv_dim + d];
+                    }
+                    scores[i * seq_len + j] = dot * scale;
+                }
+            }
+#endif
+
+            /* Causal mask + padding mask + softmax */
+            for (int i = 0; i < seq_len; i++) {
+                for (int j = 0; j < seq_len; j++) {
+                    if (j > i) scores[i * seq_len + j] = -1e9f;
+                    if (attention_mask && attention_mask[j] == 0)
+                        scores[i * seq_len + j] = -1e9f;
+                }
+                mistral_softmax(scores + i * seq_len, seq_len);
+            }
+
+            const float *v_strided = model->v_buf + kv_h * head_dim;
+            float *out_strided = model->attn_out + h * head_dim;
+
+#ifdef USE_BLAS
+            cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                        seq_len, head_dim, seq_len,
+                        1.0f, scores, seq_len, v_strided, kv_dim,
+                        0.0f, out_strided, q_dim);
+#else
+            for (int i = 0; i < seq_len; i++) {
+                for (int d = 0; d < head_dim; d++) {
+                    float sum = 0.0f;
+                    for (int j = 0; j < seq_len; j++) {
+                        sum += scores[i * seq_len + j] * v_strided[j * kv_dim + d];
+                    }
+                    out_strided[i * q_dim + d] = sum;
+                }
+            }
+#endif
+        }
+    }
+
+#ifdef USE_METAL
+output_proj:
+#endif
+    /* Output projection */
+    mistral_linear(model->hidden_state, model->attn_out, layer->attn.o_proj_weight,
+                   seq_len, q_dim, hidden);
+}
+
+/* ========================================================================
+ * MLP (CPU Path)
+ * ======================================================================== */
+
+static void mistral_mlp_forward(mistral_model_t *model, mistral_layer_t *layer, int seq_len) {
+    int hidden = model->hidden_size;
+    int intermediate = model->intermediate_size;
+
+    /* Gate and Up projections */
+    mistral_linear(model->mlp_gate, model->norm_buf, layer->mlp.gate_proj_weight,
+                   seq_len, hidden, intermediate);
+    mistral_linear(model->mlp_up, model->norm_buf, layer->mlp.up_proj_weight,
+                   seq_len, hidden, intermediate);
+
+    /* SwiGLU: silu(gate) * up */
+    for (int i = 0; i < seq_len * intermediate; i++) {
+        float gate = model->mlp_gate[i];
+        float sigmoid_val = 1.0f / (1.0f + fast_expf(-gate));
+        model->mlp_gate[i] = gate * sigmoid_val * model->mlp_up[i];
+    }
+
+    /* Down projection */
+    mistral_linear(model->mlp_out, model->mlp_gate, layer->mlp.down_proj_weight,
+                   seq_len, intermediate, hidden);
+}
+
+/* ========================================================================
+ * Layer Forward (CPU)
+ * ======================================================================== */
+
+static void mistral_layer_forward(mistral_model_t *model, mistral_layer_t *layer,
+                                   int seq_len, const int *attention_mask) {
+    int hidden = model->hidden_size;
+
+    memcpy(model->residual, model->hidden_state, seq_len * hidden * sizeof(float));
+    mistral_rms_norm(model->norm_buf, model->hidden_state, layer->input_layernorm_weight,
+                     seq_len, hidden, MISTRAL_RMS_NORM_EPS);
+    mistral_attention_forward(model, layer, seq_len, attention_mask);
+    for (int i = 0; i < seq_len * hidden; i++)
+        model->hidden_state[i] += model->residual[i];
+
+    memcpy(model->residual, model->hidden_state, seq_len * hidden * sizeof(float));
+    mistral_rms_norm(model->norm_buf, model->hidden_state, layer->post_attention_layernorm_weight,
+                     seq_len, hidden, MISTRAL_RMS_NORM_EPS);
+    mistral_mlp_forward(model, layer, seq_len);
+    for (int i = 0; i < seq_len * hidden; i++)
+        model->hidden_state[i] = model->residual[i] + model->mlp_out[i];
+}
+
+#ifdef USE_METAL
+/* ========================================================================
+ * BF16 GPU-Accelerated Paths
+ * ======================================================================== */
+
+static iris_gpu_tensor_t mistral_f32_to_bf16_tensor(const float *data, int n) {
+    iris_gpu_tensor_t f32_tensor = iris_gpu_tensor_create(data, n);
+    if (!f32_tensor) return NULL;
+    iris_gpu_tensor_t bf16_tensor = iris_gpu_tensor_f32_to_bf16(f32_tensor);
+    iris_gpu_tensor_free(f32_tensor);
+    return bf16_tensor;
+}
+
+/* GPU-only attention: no Q/K norm (Mistral-specific) */
+static iris_gpu_tensor_t mistral_attention_gpu(mistral_model_t *model,
+                                                mistral_layer_t *layer,
+                                                iris_gpu_tensor_t norm_out,
+                                                int seq_len,
+                                                const int *attention_mask) {
+    int num_heads = model->num_heads;
+    int num_kv_heads = model->num_kv_heads;
+    int head_dim = model->head_dim;
+    int hidden = model->hidden_size;
+    int q_dim = num_heads * head_dim;
+    int kv_dim = num_kv_heads * head_dim;
+    float scale = 1.0f / sqrtf((float)head_dim);
+
+    /* Q, K, V projections */
+    iris_gpu_tensor_t q = iris_gpu_linear_bf16_native(norm_out, layer->attn.q_proj_weight_bf16,
+                                                       seq_len, hidden, q_dim);
+    iris_gpu_tensor_t k = iris_gpu_linear_bf16_native(norm_out, layer->attn.k_proj_weight_bf16,
+                                                       seq_len, hidden, kv_dim);
+    iris_gpu_tensor_t v = iris_gpu_linear_bf16_native(norm_out, layer->attn.v_proj_weight_bf16,
+                                                       seq_len, hidden, kv_dim);
+    if (!q || !k || !v) goto fail_qkv;
+
+    /* NO Q/K norm — Mistral skips this */
+
+    /* RoPE */
+    iris_gpu_rope_text_bf16(q, k, model->rope_cos, model->rope_sin,
+                             seq_len, num_heads, num_kv_heads, head_dim);
+
+    /* Causal attention */
+    iris_gpu_tensor_t attn_out = iris_gpu_tensor_alloc_f16(seq_len * q_dim);
+    if (!attn_out) goto fail_qkv;
+    if (!iris_gpu_causal_attention_bf16(attn_out, q, k, v, attention_mask,
+                                        seq_len, num_heads, num_kv_heads,
+                                        head_dim, scale)) {
+        iris_gpu_tensor_free(attn_out);
+        goto fail_qkv;
+    }
+    iris_gpu_tensor_free(q);
+    iris_gpu_tensor_free(k);
+    iris_gpu_tensor_free(v);
+
+    /* O projection */
+    iris_gpu_tensor_t out = iris_gpu_linear_bf16_native(attn_out, layer->attn.o_proj_weight_bf16,
+                                                         seq_len, q_dim, hidden);
+    iris_gpu_tensor_free(attn_out);
+    return out;
+
+fail_qkv:
+    if (q) iris_gpu_tensor_free(q);
+    if (k) iris_gpu_tensor_free(k);
+    if (v) iris_gpu_tensor_free(v);
+    return NULL;
+}
+
+/* GPU-only MLP */
+static iris_gpu_tensor_t mistral_mlp_gpu(mistral_model_t *model, mistral_layer_t *layer,
+                                           iris_gpu_tensor_t norm_out, int seq_len) {
+    int hidden = model->hidden_size;
+    int intermediate = model->intermediate_size;
+
+    iris_gpu_tensor_t gate = iris_gpu_linear_bf16_native(norm_out, layer->mlp.gate_proj_weight_bf16,
+                                                          seq_len, hidden, intermediate);
+    iris_gpu_tensor_t up = iris_gpu_linear_bf16_native(norm_out, layer->mlp.up_proj_weight_bf16,
+                                                        seq_len, hidden, intermediate);
+    if (!gate || !up) {
+        if (gate) iris_gpu_tensor_free(gate);
+        if (up) iris_gpu_tensor_free(up);
+        return NULL;
+    }
+
+    iris_gpu_silu_mul_bf16(gate, up, seq_len * intermediate);
+    iris_gpu_tensor_free(up);
+
+    iris_gpu_tensor_t out = iris_gpu_linear_bf16_native(gate, layer->mlp.down_proj_weight_bf16,
+                                                         seq_len, intermediate, hidden);
+    iris_gpu_tensor_free(gate);
+    return out;
+}
+
+/* Fully GPU-resident forward pass */
+static int mistral_forward_gpu(mistral_model_t *model, int seq_len, const int *attention_mask) {
+    int hidden = model->hidden_size;
+    int last_layer = MISTRAL_OUTPUT_LAYER_3;
+
+    iris_gpu_batch_begin();
+    iris_gpu_tensor_t hidden_gpu = mistral_f32_to_bf16_tensor(model->hidden_state, seq_len * hidden);
+    if (!hidden_gpu) {
+        iris_gpu_batch_end();
+        return 0;
+    }
+
+    iris_gpu_tensor_t saved[3] = {NULL, NULL, NULL};
+    for (int i = 0; i < 3; i++) {
+        saved[i] = iris_gpu_tensor_alloc_f16(seq_len * hidden);
+        if (!saved[i]) {
+            for (int j = 0; j <= i; j++) if (saved[j]) iris_gpu_tensor_free(saved[j]);
+            iris_gpu_tensor_free(hidden_gpu);
+            iris_gpu_batch_end();
+            return 0;
+        }
+    }
+
+    int ok = 1;
+
+    for (int layer_idx = 0; layer_idx <= last_layer; layer_idx++) {
+        mistral_layer_t *layer = &model->layers[layer_idx];
+
+        /* Load weights on demand */
+        if (model->use_mmap) {
+            if (mistral_load_layer_small_f32(layer, model->sf_files, model->num_sf_files, layer_idx) != 0) {
+                ok = 0; break;
+            }
+            mistral_load_layer_bf16(layer, model->sf_files, model->num_sf_files, layer_idx);
+        }
+
+        if (!layer->attn.q_proj_weight_bf16 || !layer->mlp.gate_proj_weight_bf16) {
+            ok = 0; break;
+        }
+
+        /* Input RMS norm */
+        iris_gpu_tensor_t norm_w = mistral_f32_to_bf16_tensor(layer->input_layernorm_weight, hidden);
+        iris_gpu_tensor_t norm_out = iris_gpu_tensor_alloc_f16(seq_len * hidden);
+        if (!norm_w || !norm_out) {
+            if (norm_w) iris_gpu_tensor_free(norm_w);
+            if (norm_out) iris_gpu_tensor_free(norm_out);
+            ok = 0; break;
+        }
+        iris_gpu_rms_norm_bf16(norm_out, hidden_gpu, norm_w, seq_len, hidden, MISTRAL_RMS_NORM_EPS);
+        iris_gpu_tensor_free(norm_w);
+
+        /* Attention */
+        iris_gpu_tensor_t attn_out = mistral_attention_gpu(model, layer, norm_out, seq_len, attention_mask);
+        iris_gpu_tensor_free(norm_out);
+        if (!attn_out) { ok = 0; break; }
+
+        /* Residual */
+        iris_gpu_add_bf16(hidden_gpu, hidden_gpu, attn_out, seq_len * hidden);
+        iris_gpu_tensor_free(attn_out);
+
+        /* Post-attention RMS norm */
+        iris_gpu_tensor_t post_norm_w = mistral_f32_to_bf16_tensor(layer->post_attention_layernorm_weight, hidden);
+        norm_out = iris_gpu_tensor_alloc_f16(seq_len * hidden);
+        if (!post_norm_w || !norm_out) {
+            if (post_norm_w) iris_gpu_tensor_free(post_norm_w);
+            if (norm_out) iris_gpu_tensor_free(norm_out);
+            ok = 0; break;
+        }
+        iris_gpu_rms_norm_bf16(norm_out, hidden_gpu, post_norm_w, seq_len, hidden, MISTRAL_RMS_NORM_EPS);
+        iris_gpu_tensor_free(post_norm_w);
+
+        /* MLP */
+        iris_gpu_tensor_t mlp_out = mistral_mlp_gpu(model, layer, norm_out, seq_len);
+        iris_gpu_tensor_free(norm_out);
+        if (!mlp_out) { ok = 0; break; }
+
+        /* Residual */
+        iris_gpu_add_bf16(hidden_gpu, hidden_gpu, mlp_out, seq_len * hidden);
+        iris_gpu_tensor_free(mlp_out);
+
+        /* Free layer weights */
+        if (model->use_mmap) {
+            mistral_free_layer_weights(layer);
+        }
+
+        /* Save at extraction layers */
+        if (layer_idx == MISTRAL_OUTPUT_LAYER_1)
+            iris_gpu_copy_bf16(saved[0], hidden_gpu, seq_len * hidden);
+        else if (layer_idx == MISTRAL_OUTPUT_LAYER_2)
+            iris_gpu_copy_bf16(saved[1], hidden_gpu, seq_len * hidden);
+        else if (layer_idx == MISTRAL_OUTPUT_LAYER_3)
+            iris_gpu_copy_bf16(saved[2], hidden_gpu, seq_len * hidden);
+
+        if (iris_text_progress_callback)
+            iris_text_progress_callback(layer_idx, last_layer + 1);
+    }
+
+    if (!ok) {
+        iris_gpu_batch_end();
+        for (int i = 0; i < 3; i++) if (saved[i]) iris_gpu_tensor_free(saved[i]);
+        iris_gpu_tensor_free(hidden_gpu);
+        return 0;
+    }
+
+    /* Convert saved bf16 → f32 */
+    iris_gpu_tensor_t saved_f32[3] = {NULL, NULL, NULL};
+    for (int i = 0; i < 3; i++)
+        saved_f32[i] = iris_gpu_tensor_bf16_to_f32(saved[i]);
+
+    iris_gpu_batch_end();
+
+    if (iris_text_progress_callback)
+        iris_text_progress_callback(last_layer, last_layer + 1);
+
+    /* Read results to CPU */
+    int read_ok = 1;
+    for (int i = 0; i < 3; i++) {
+        if (saved_f32[i]) {
+            iris_gpu_tensor_read(saved_f32[i], model->layer_outputs[i]);
+            iris_gpu_tensor_free(saved_f32[i]);
+        } else {
+            read_ok = 0;
+        }
+        iris_gpu_tensor_free(saved[i]);
+    }
+    iris_gpu_tensor_free(hidden_gpu);
+
+    return read_ok;
+}
+
+#endif /* USE_METAL */
+
+/* ========================================================================
+ * Forward Pass
+ * ======================================================================== */
+
+float *mistral_forward(mistral_model_t *model, const int *input_ids,
+                       const int *attention_mask, int seq_len) {
+    int hidden = model->hidden_size;
+    int last_layer = MISTRAL_OUTPUT_LAYER_3;
+    float *output;
+
+    /* Find last real token position for pooled embedding */
+    model->pooled_seq_idx = 0;
+    if (attention_mask) {
+        for (int i = seq_len - 1; i >= 0; i--) {
+            if (attention_mask[i] == 1) {
+                model->pooled_seq_idx = i;
+                break;
+            }
+        }
+    }
+
+    /* Embedding lookup */
+    for (int s = 0; s < seq_len; s++) {
+        int token_id = input_ids[s];
+        if (token_id >= 0 && token_id < model->vocab_size) {
+            memcpy(model->hidden_state + s * hidden,
+                   model->embed_tokens + token_id * hidden,
+                   hidden * sizeof(float));
+        } else {
+            memset(model->hidden_state + s * hidden, 0, hidden * sizeof(float));
+        }
+    }
+
+    /* Try GPU-resident path */
+#ifdef USE_METAL
+    if (model->use_bf16 && iris_metal_available() && seq_len <= 512) {
+        if (mistral_forward_gpu(model, seq_len, attention_mask))
+            goto concatenate;
+    }
+#endif
+
+    /* CPU / mixed path */
+    for (int layer_idx = 0; layer_idx <= last_layer; layer_idx++) {
+        if (model->use_mmap) {
+            if (mistral_load_layer_weights(&model->layers[layer_idx], model->sf_files,
+                                            model->num_sf_files, layer_idx) != 0) {
+                fprintf(stderr, "Failed to load Mistral layer %d weights\n", layer_idx);
+                return NULL;
+            }
+        }
+
+        mistral_layer_forward(model, &model->layers[layer_idx], seq_len, attention_mask);
+
+        if (model->use_mmap) {
+            mistral_free_layer_weights(&model->layers[layer_idx]);
+        }
+
+        if (layer_idx == MISTRAL_OUTPUT_LAYER_1)
+            memcpy(model->layer_outputs[0], model->hidden_state, seq_len * hidden * sizeof(float));
+        else if (layer_idx == MISTRAL_OUTPUT_LAYER_2)
+            memcpy(model->layer_outputs[1], model->hidden_state, seq_len * hidden * sizeof(float));
+        else if (layer_idx == MISTRAL_OUTPUT_LAYER_3)
+            memcpy(model->layer_outputs[2], model->hidden_state, seq_len * hidden * sizeof(float));
+
+        if (iris_text_progress_callback)
+            iris_text_progress_callback(layer_idx, last_layer + 1);
+    }
+
+    /* Concatenate extracted layers → [seq_len, 3*hidden] */
+#ifdef USE_METAL
+concatenate: (void)0;
+#endif
+    {
+        int text_dim = model->text_dim;
+        output = malloc(seq_len * text_dim * sizeof(float));
+        if (!output) return NULL;
+
+        for (int s = 0; s < seq_len; s++) {
+            memcpy(output + s * text_dim,
+                   model->layer_outputs[0] + s * hidden,
+                   hidden * sizeof(float));
+            memcpy(output + s * text_dim + hidden,
+                   model->layer_outputs[1] + s * hidden,
+                   hidden * sizeof(float));
+            memcpy(output + s * text_dim + 2 * hidden,
+                   model->layer_outputs[2] + s * hidden,
+                   hidden * sizeof(float));
+        }
+    }
+
+    /* Store pooled embedding (last real token from layer 30 output) */
+    if (model->pooled_output) {
+        memcpy(model->pooled_output,
+               model->layer_outputs[2] + model->pooled_seq_idx * hidden,
+               hidden * sizeof(float));
+    }
+
+    return output;
+}
+
+const float *mistral_get_pooled(mistral_model_t *model) {
+    if (!model || !model->pooled_output) return NULL;
+    return model->pooled_output;
+}
+
+/* ========================================================================
+ * Weight Loading
+ * ======================================================================== */
+
+static float *mistral_load_tensor(safetensors_file_t **files, int num_files, const char *name) {
+    for (int f = 0; f < num_files; f++) {
+        const safetensor_t *t = safetensors_find(files[f], name);
+        if (t) return safetensors_get_f32(files[f], t);
+    }
+    fprintf(stderr, "Error: required tensor not found: %s\n", name);
+    return NULL;
+}
+
+#ifdef USE_METAL
+static uint16_t *mistral_load_tensor_bf16(safetensors_file_t **files, int num_files, const char *name) {
+    for (int f = 0; f < num_files; f++) {
+        const safetensor_t *t = safetensors_find(files[f], name);
+        if (t && safetensor_is_bf16(t)) {
+            return safetensors_get_bf16_direct(files[f], t);
+        }
+    }
+    return NULL;
+}
+
+static int mistral_load_layer_small_f32(mistral_layer_t *layer, safetensors_file_t **files,
+                                         int num_files, int layer_idx) {
+    char name[256];
+
+    snprintf(name, sizeof(name), "model.layers.%d.input_layernorm.weight", layer_idx);
+    layer->input_layernorm_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.post_attention_layernorm.weight", layer_idx);
+    layer->post_attention_layernorm_weight = mistral_load_tensor(files, num_files, name);
+
+    /* No Q/K norm for Mistral */
+
+    return (layer->input_layernorm_weight && layer->post_attention_layernorm_weight) ? 0 : -1;
+}
+
+static int mistral_load_layer_bf16(mistral_layer_t *layer, safetensors_file_t **files,
+                                    int num_files, int layer_idx) {
+    char name[256];
+
+    snprintf(name, sizeof(name), "model.layers.%d.self_attn.q_proj.weight", layer_idx);
+    layer->attn.q_proj_weight_bf16 = mistral_load_tensor_bf16(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.self_attn.k_proj.weight", layer_idx);
+    layer->attn.k_proj_weight_bf16 = mistral_load_tensor_bf16(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.self_attn.v_proj.weight", layer_idx);
+    layer->attn.v_proj_weight_bf16 = mistral_load_tensor_bf16(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.self_attn.o_proj.weight", layer_idx);
+    layer->attn.o_proj_weight_bf16 = mistral_load_tensor_bf16(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.mlp.gate_proj.weight", layer_idx);
+    layer->mlp.gate_proj_weight_bf16 = mistral_load_tensor_bf16(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.mlp.up_proj.weight", layer_idx);
+    layer->mlp.up_proj_weight_bf16 = mistral_load_tensor_bf16(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.mlp.down_proj.weight", layer_idx);
+    layer->mlp.down_proj_weight_bf16 = mistral_load_tensor_bf16(files, num_files, name);
+
+    return (layer->attn.q_proj_weight_bf16 && layer->attn.k_proj_weight_bf16 &&
+            layer->attn.v_proj_weight_bf16 && layer->attn.o_proj_weight_bf16 &&
+            layer->mlp.gate_proj_weight_bf16 && layer->mlp.up_proj_weight_bf16 &&
+            layer->mlp.down_proj_weight_bf16);
+}
+#endif
+
+static int mistral_load_layer_weights(mistral_layer_t *layer, safetensors_file_t **files,
+                                       int num_files, int layer_idx) {
+    char name[256];
+
+    snprintf(name, sizeof(name), "model.layers.%d.input_layernorm.weight", layer_idx);
+    layer->input_layernorm_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.post_attention_layernorm.weight", layer_idx);
+    layer->post_attention_layernorm_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.self_attn.q_proj.weight", layer_idx);
+    layer->attn.q_proj_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.self_attn.k_proj.weight", layer_idx);
+    layer->attn.k_proj_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.self_attn.v_proj.weight", layer_idx);
+    layer->attn.v_proj_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.self_attn.o_proj.weight", layer_idx);
+    layer->attn.o_proj_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.mlp.gate_proj.weight", layer_idx);
+    layer->mlp.gate_proj_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.mlp.up_proj.weight", layer_idx);
+    layer->mlp.up_proj_weight = mistral_load_tensor(files, num_files, name);
+
+    snprintf(name, sizeof(name), "model.layers.%d.mlp.down_proj.weight", layer_idx);
+    layer->mlp.down_proj_weight = mistral_load_tensor(files, num_files, name);
+
+    if (!layer->input_layernorm_weight || !layer->post_attention_layernorm_weight ||
+        !layer->attn.q_proj_weight || !layer->attn.k_proj_weight ||
+        !layer->attn.v_proj_weight || !layer->attn.o_proj_weight ||
+        !layer->mlp.gate_proj_weight || !layer->mlp.up_proj_weight ||
+        !layer->mlp.down_proj_weight) {
+        return -1;
+    }
+    return 0;
+}
+
+static void mistral_free_layer_weights(mistral_layer_t *layer) {
+    free(layer->input_layernorm_weight);
+    free(layer->post_attention_layernorm_weight);
+    free(layer->attn.q_proj_weight);
+    free(layer->attn.k_proj_weight);
+    free(layer->attn.v_proj_weight);
+    free(layer->attn.o_proj_weight);
+    free(layer->mlp.gate_proj_weight);
+    free(layer->mlp.up_proj_weight);
+    free(layer->mlp.down_proj_weight);
+
+    memset(layer, 0, sizeof(mistral_layer_t));
+}
+
+/* ========================================================================
+ * Config Parsing
+ * ======================================================================== */
+
+static int parse_mistral_config(const char *model_dir, mistral_model_t *model) {
+    char path[1024];
+    snprintf(path, sizeof(path), "%s/config.json", model_dir);
+
+    FILE *f = fopen(path, "r");
+    if (!f) return -1;
+
+    char buf[8192];
+    size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+    buf[n] = '\0';
+    fclose(f);
+
+    char *p;
+    int hidden = 0, intermediate = 0, num_heads = 0, num_kv_heads = 0;
+    int head_dim = 0, vocab_size = 0, num_layers = 0;
+    float rope_theta = 0;
+
+    if ((p = strstr(buf, "\"hidden_size\"")))
+        if ((p = strchr(p, ':'))) hidden = atoi(p + 1);
+    if ((p = strstr(buf, "\"intermediate_size\"")))
+        if ((p = strchr(p, ':'))) intermediate = atoi(p + 1);
+    if ((p = strstr(buf, "\"num_attention_heads\"")))
+        if ((p = strchr(p, ':'))) num_heads = atoi(p + 1);
+    if ((p = strstr(buf, "\"num_key_value_heads\"")))
+        if ((p = strchr(p, ':'))) num_kv_heads = atoi(p + 1);
+    if ((p = strstr(buf, "\"head_dim\"")))
+        if ((p = strchr(p, ':'))) head_dim = atoi(p + 1);
+    if ((p = strstr(buf, "\"vocab_size\"")))
+        if ((p = strchr(p, ':'))) vocab_size = atoi(p + 1);
+    if ((p = strstr(buf, "\"num_hidden_layers\"")))
+        if ((p = strchr(p, ':'))) num_layers = atoi(p + 1);
+    if ((p = strstr(buf, "\"rope_theta\"")))
+        if ((p = strchr(p, ':'))) rope_theta = atof(p + 1);
+
+    if (hidden <= 0 || num_heads <= 0) return -1;
+
+    model->hidden_size = hidden;
+    model->intermediate_size = intermediate > 0 ? intermediate : 32768;
+    model->num_heads = num_heads;
+    model->num_kv_heads = num_kv_heads > 0 ? num_kv_heads : 8;
+    model->head_dim = head_dim > 0 ? head_dim : (hidden / num_heads);
+    model->vocab_size = vocab_size > 0 ? vocab_size : 131072;
+    model->num_layers = num_layers > 0 ? num_layers : 40;
+    model->rope_theta = rope_theta > 0 ? rope_theta : 1000000000.0f;
+    model->text_dim = 3 * hidden;
+
+    return 0;
+}
+
+/* ========================================================================
+ * Safetensors Shard Discovery
+ * ======================================================================== */
+
+static int mistral_open_shards(const char *model_dir,
+                                safetensors_file_t **files, int max_files) {
+    char path[1024];
+
+    /* Try index JSON first */
+    snprintf(path, sizeof(path), "%s/model.safetensors.index.json", model_dir);
+    FILE *f = fopen(path, "r");
+    if (f) {
+        fseek(f, 0, SEEK_END);
+        long fsize = ftell(f);
+        fseek(f, 0, SEEK_SET);
+        char *buf = malloc(fsize + 1);
+        if (!buf) { fclose(f); return 0; }
+        fread(buf, 1, fsize, f);
+        buf[fsize] = '\0';
+        fclose(f);
+
+        char shard_names[MISTRAL_MAX_SHARDS][128];
+        int num_shards = 0;
+
+        char *p = buf;
+        while ((p = strstr(p, "model-")) != NULL) {
+            char *end = strstr(p, ".safetensors");
+            if (!end) { p++; continue; }
+            end += strlen(".safetensors");
+
+            int len = (int)(end - p);
+            if (len >= 128) { p = end; continue; }
+
+            char name[128];
+            memcpy(name, p, len);
+            name[len] = '\0';
+
+            int found = 0;
+            for (int i = 0; i < num_shards; i++) {
+                if (strcmp(shard_names[i], name) == 0) { found = 1; break; }
+            }
+            if (!found && num_shards < max_files && num_shards < MISTRAL_MAX_SHARDS) {
+                strcpy(shard_names[num_shards], name);
+                num_shards++;
+            }
+            p = end;
+        }
+        free(buf);
+
+        if (num_shards > 0) {
+            for (int i = 0; i < num_shards; i++) {
+                snprintf(path, sizeof(path), "%s/%s", model_dir, shard_names[i]);
+                files[i] = safetensors_open(path);
+                if (!files[i]) {
+                    fprintf(stderr, "mistral: failed to open shard %s\n", path);
+                    for (int j = 0; j < i; j++) safetensors_close(files[j]);
+                    return 0;
+                }
+            }
+            return num_shards;
+        }
+    }
+
+    /* Fallback: single model.safetensors */
+    snprintf(path, sizeof(path), "%s/model.safetensors", model_dir);
+    files[0] = safetensors_open(path);
+    if (files[0]) return 1;
+
+    return 0;
+}
+
+/* ========================================================================
+ * Model Loading (always mmap)
+ * ======================================================================== */
+
+static void mistral_alloc_work_buffers(mistral_model_t *model) {
+    int seq_len = MISTRAL_MAX_SEQ_LEN;
+    int hidden = model->hidden_size;
+    int num_heads = model->num_heads;
+    int num_kv_heads = model->num_kv_heads;
+    int head_dim = model->head_dim;
+    int intermediate = model->intermediate_size;
+
+    model->hidden_state = malloc(seq_len * hidden * sizeof(float));
+    model->residual = malloc(seq_len * hidden * sizeof(float));
+    model->q_buf = malloc(seq_len * num_heads * head_dim * sizeof(float));
+    model->k_buf = malloc(seq_len * num_kv_heads * head_dim * sizeof(float));
+    model->v_buf = malloc(seq_len * num_kv_heads * head_dim * sizeof(float));
+    model->attn_scores = malloc(num_heads * seq_len * seq_len * sizeof(float));
+    model->attn_out = malloc(seq_len * num_heads * head_dim * sizeof(float));
+    model->mlp_gate = malloc(seq_len * intermediate * sizeof(float));
+    model->mlp_up = malloc(seq_len * intermediate * sizeof(float));
+    model->mlp_out = malloc(seq_len * hidden * sizeof(float));
+    model->norm_buf = malloc(seq_len * hidden * sizeof(float));
+
+    model->attn_q_head = malloc(seq_len * head_dim * sizeof(float));
+    model->attn_v_head = malloc(seq_len * head_dim * sizeof(float));
+    model->attn_out_head = malloc(seq_len * head_dim * sizeof(float));
+
+    for (int i = 0; i < 3; i++) {
+        model->layer_outputs[i] = malloc(seq_len * hidden * sizeof(float));
+    }
+
+    model->pooled_output = malloc(hidden * sizeof(float));
+}
+
+mistral_model_t *mistral_model_load_mmap(const char *model_dir) {
+    mistral_model_t *model = calloc(1, sizeof(mistral_model_t));
+    if (!model) return NULL;
+
+    model->use_mmap = 1;
+
+    if (parse_mistral_config(model_dir, model) != 0) {
+        fprintf(stderr, "mistral_model_load_mmap: failed to parse config.json\n");
+        free(model);
+        return NULL;
+    }
+
+    if (iris_verbose)
+        fprintf(stderr, "Mistral config: hidden=%d, heads=%d/%d, head_dim=%d, layers=%d, ff=%d, rope_theta=%.0f\n",
+                model->hidden_size, model->num_heads, model->num_kv_heads,
+                model->head_dim, model->num_layers, model->intermediate_size, model->rope_theta);
+
+#ifdef USE_METAL
+    model->use_bf16 = (iris_metal_available() && !getenv("IRIS_MISTRAL_NO_BF16")) ? 1 : 0;
+    if (model->use_bf16 && iris_verbose)
+        fprintf(stderr, "Mistral: bf16 GPU acceleration enabled\n");
+#endif
+
+    model->layers = calloc(model->num_layers, sizeof(mistral_layer_t));
+    if (!model->layers) {
+        free(model);
+        return NULL;
+    }
+
+    /* Open safetensors shards */
+    model->num_sf_files = mistral_open_shards(model_dir, model->sf_files, MISTRAL_MAX_SHARDS);
+    if (model->num_sf_files == 0) {
+        fprintf(stderr, "mistral_model_load_mmap: failed to open safetensors files\n");
+        goto error;
+    }
+
+    /* Load embeddings (large but needed for all tokens) */
+    model->embed_tokens = mistral_load_tensor(model->sf_files, model->num_sf_files,
+                                               "model.embed_tokens.weight");
+    if (!model->embed_tokens) {
+        fprintf(stderr, "mistral_model_load_mmap: failed to load embed_tokens\n");
+        goto error;
+    }
+
+    /* Load final norm */
+    model->norm_weight = mistral_load_tensor(model->sf_files, model->num_sf_files,
+                                              "model.norm.weight");
+    if (!model->norm_weight) {
+        fprintf(stderr, "mistral_model_load_mmap: failed to load final norm\n");
+        goto error;
+    }
+
+    if (iris_verbose)
+        fprintf(stderr, "Mistral mmap mode: layer weights will be loaded on-demand\n");
+
+    /* Compute RoPE frequencies */
+    int max_seq = MISTRAL_MAX_SEQ_LEN;
+    int half_dim = model->head_dim / 2;
+    model->rope_cos = malloc(max_seq * half_dim * sizeof(float));
+    model->rope_sin = malloc(max_seq * half_dim * sizeof(float));
+    mistral_compute_rope_freqs(model->rope_cos, model->rope_sin, max_seq,
+                                model->head_dim, model->rope_theta);
+
+    /* Allocate working memory */
+    mistral_alloc_work_buffers(model);
+
+    return model;
+
+error:
+    mistral_model_free(model);
+    return NULL;
+}
+
+void mistral_model_free(mistral_model_t *model) {
+    if (!model) return;
+
+    free(model->embed_tokens);
+    free(model->norm_weight);
+    free(model->rope_cos);
+    free(model->rope_sin);
+
+    if (model->layers) {
+        for (int i = 0; i < model->num_layers; i++) {
+            mistral_layer_t *layer = &model->layers[i];
+            free(layer->input_layernorm_weight);
+            free(layer->post_attention_layernorm_weight);
+            free(layer->attn.q_proj_weight);
+            free(layer->attn.k_proj_weight);
+            free(layer->attn.v_proj_weight);
+            free(layer->attn.o_proj_weight);
+            free(layer->mlp.gate_proj_weight);
+            free(layer->mlp.up_proj_weight);
+            free(layer->mlp.down_proj_weight);
+        }
+        free(model->layers);
+    }
+
+    free(model->hidden_state);
+    free(model->residual);
+    free(model->q_buf);
+    free(model->k_buf);
+    free(model->v_buf);
+    free(model->attn_scores);
+    free(model->attn_out);
+    free(model->mlp_gate);
+    free(model->mlp_up);
+    free(model->mlp_out);
+    free(model->norm_buf);
+    free(model->attn_q_head);
+    free(model->attn_v_head);
+    free(model->attn_out_head);
+
+    for (int i = 0; i < 3; i++) free(model->layer_outputs[i]);
+    free(model->pooled_output);
+
+    for (int i = 0; i < model->num_sf_files; i++) {
+        if (model->sf_files[i]) safetensors_close(model->sf_files[i]);
+    }
+
+    free(model);
+}
+
+/* ========================================================================
+ * Combined Encoder API
+ * ======================================================================== */
+
+mistral_encoder_t *mistral_encoder_load(const char *model_dir) {
+    mistral_encoder_t *enc = calloc(1, sizeof(mistral_encoder_t));
+    if (!enc) return NULL;
+
+    /* Load tokenizer */
+    char tok_path[512];
+    snprintf(tok_path, sizeof(tok_path), "%s/tokenizer/tokenizer.json", model_dir);
+
+    /* Try tokenizer/ subdir first, then text_encoder/tokenizer.json */
+    enc->tokenizer = mistral_tokenizer_load(tok_path);
+    if (!enc->tokenizer) {
+        snprintf(tok_path, sizeof(tok_path), "%s/text_encoder/tokenizer.json", model_dir);
+        enc->tokenizer = mistral_tokenizer_load(tok_path);
+    }
+    if (!enc->tokenizer) {
+        fprintf(stderr, "mistral_encoder_load: failed to load tokenizer\n");
+        free(enc);
+        return NULL;
+    }
+
+    /* Load model (always mmap — Mistral is ~48GB) */
+    char model_path[512];
+    snprintf(model_path, sizeof(model_path), "%s/text_encoder", model_dir);
+    enc->model = mistral_model_load_mmap(model_path);
+    if (!enc->model) {
+        fprintf(stderr, "mistral_encoder_load: failed to load model\n");
+        mistral_tokenizer_free(enc->tokenizer);
+        free(enc);
+        return NULL;
+    }
+
+    return enc;
+}
+
+void mistral_encoder_free(mistral_encoder_t *enc) {
+    if (!enc) return;
+    mistral_tokenizer_free(enc->tokenizer);
+    mistral_model_free(enc->model);
+    free(enc);
+}
+
+float *mistral_encode_text(mistral_encoder_t *enc, const char *prompt,
+                           int *out_num_tokens) {
+    if (!enc || !enc->tokenizer || !enc->model || !prompt) return NULL;
+
+    /* Tokenize with chat template */
+    int num_tokens;
+    int *tokens = mistral_tokenize_chat(enc->tokenizer, prompt, &num_tokens,
+                                         MISTRAL_MAX_SEQ_LEN);
+    if (!tokens) return NULL;
+
+    /* Pad to max length */
+    int *attention_mask = malloc(MISTRAL_MAX_SEQ_LEN * sizeof(int));
+    int *padded_tokens = mistral_pad_tokens(tokens, num_tokens, MISTRAL_MAX_SEQ_LEN, attention_mask);
+    free(tokens);
+
+    if (!padded_tokens) {
+        free(attention_mask);
+        return NULL;
+    }
+
+    if (out_num_tokens) *out_num_tokens = num_tokens;
+
+    /* Forward pass */
+    float *embeddings = mistral_forward(enc->model, padded_tokens, attention_mask, MISTRAL_MAX_SEQ_LEN);
+
+    free(padded_tokens);
+    free(attention_mask);
+
+    return embeddings;
+}

--- a/iris_mistral.h
+++ b/iris_mistral.h
@@ -1,0 +1,143 @@
+/*
+ * Mistral-Small-3.2-24B Text Encoder for Iris
+ *
+ * Implements the Mistral text encoder for FLUX.2-dev image generation.
+ * Architecture is very similar to Qwen3 (GQA, SwiGLU, RoPE, RMSNorm)
+ * with key differences: no Q/K norm, different extraction layers (10/20/30),
+ * and a pooled embedding output for the transformer's text_embedder.
+ */
+
+#ifndef IRIS_MISTRAL_H
+#define IRIS_MISTRAL_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ========================================================================
+ * Architecture Constants
+ * ======================================================================== */
+
+/* Fixed constants */
+#define MISTRAL_MAX_SEQ_LEN     512
+#define MISTRAL_RMS_NORM_EPS    1e-5f
+
+/* Output layers to extract (0-indexed).
+ * Hidden states from layers 10, 20, 30 are concatenated → [seq, 3*hidden]. */
+#define MISTRAL_OUTPUT_LAYER_1  10
+#define MISTRAL_OUTPUT_LAYER_2  20
+#define MISTRAL_OUTPUT_LAYER_3  30
+
+/* ========================================================================
+ * Opaque Types
+ * ======================================================================== */
+
+typedef struct mistral_model mistral_model_t;
+typedef struct mistral_tokenizer mistral_tokenizer_t;
+
+/* ========================================================================
+ * Tokenizer API
+ * ======================================================================== */
+
+/*
+ * Load tokenizer from HuggingFace tokenizer.json file.
+ */
+mistral_tokenizer_t *mistral_tokenizer_load(const char *tokenizer_json_path);
+
+/*
+ * Free tokenizer resources.
+ */
+void mistral_tokenizer_free(mistral_tokenizer_t *tok);
+
+/*
+ * Tokenize text with Mistral chat template.
+ * Format: [INST] {prompt} [/INST]
+ */
+int *mistral_tokenize_chat(mistral_tokenizer_t *tok, const char *prompt,
+                           int *num_tokens, int max_len);
+
+/*
+ * Pad tokens to max_len with PAD token.
+ * Returns new array, caller must free original.
+ */
+int *mistral_pad_tokens(int *tokens, int num_tokens, int max_len, int *attention_mask);
+
+/*
+ * Get token string by ID.
+ */
+const char *mistral_get_token(mistral_tokenizer_t *tok, int id);
+
+/* ========================================================================
+ * Model API
+ * ======================================================================== */
+
+/*
+ * Load Mistral model in mmap mode from HuggingFace model directory.
+ * Only loads embeddings + final norm; layer weights loaded on-demand.
+ */
+mistral_model_t *mistral_model_load_mmap(const char *model_dir);
+
+/*
+ * Free model resources.
+ */
+void mistral_model_free(mistral_model_t *model);
+
+/*
+ * Run forward pass to generate text embeddings.
+ *
+ * input_ids: Token IDs [seq_len]
+ * attention_mask: Attention mask [seq_len] (1 for real tokens, 0 for padding)
+ * seq_len: Length of input sequences
+ *
+ * Returns: Embedding array [seq_len, 3*hidden_size] (caller must free)
+ * Extracts hidden states from layers 10, 20, 30 and concatenates them.
+ */
+float *mistral_forward(mistral_model_t *model,
+                       const int *input_ids,
+                       const int *attention_mask,
+                       int seq_len);
+
+/*
+ * Get pooled embedding after forward pass (last real token hidden state).
+ * Returns pointer to internal buffer [hidden_size]. Do NOT free.
+ * Valid until next forward pass or model_free.
+ */
+const float *mistral_get_pooled(mistral_model_t *model);
+
+/* ========================================================================
+ * Combined Text Encoder API
+ * ======================================================================== */
+
+typedef struct mistral_encoder {
+    mistral_tokenizer_t *tokenizer;
+    mistral_model_t *model;
+} mistral_encoder_t;
+
+/*
+ * Load complete text encoder (tokenizer + model).
+ * model_dir should contain both tokenizer/ and text_encoder/ subdirectories.
+ * Always uses mmap mode (Mistral is ~48GB, must stream layers).
+ */
+mistral_encoder_t *mistral_encoder_load(const char *model_dir);
+
+/*
+ * Free encoder resources.
+ */
+void mistral_encoder_free(mistral_encoder_t *enc);
+
+/*
+ * Encode text prompt to embeddings.
+ * Returns: Embedding array [512, 3*hidden_size] (caller must free)
+ * Also stores pooled embedding internally (retrieve via mistral_get_pooled on enc->model).
+ * out_num_tokens: if non-NULL, receives the number of real (non-padding) tokens.
+ */
+float *mistral_encode_text(mistral_encoder_t *enc, const char *prompt,
+                           int *out_num_tokens);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* IRIS_MISTRAL_H */

--- a/iris_mistral_tokenizer.c
+++ b/iris_mistral_tokenizer.c
@@ -1,0 +1,986 @@
+/*
+ * Mistral-Small-3.2-24B Tokenizer Implementation
+ *
+ * BPE tokenizer for Mistral text encoder (Tekken/SentencePiece-based BPE).
+ * Loads from HuggingFace tokenizer.json format. Core BPE algorithm is
+ * identical to Qwen3, but uses different byte encoding, special tokens,
+ * and chat template.
+ *
+ * Key differences from Qwen3 tokenizer:
+ * - No GPT-2 byte-to-unicode encoding (Tekken works on raw UTF-8)
+ * - Chat template: [INST] {prompt} [/INST] (not <|im_start|>)
+ * - Special tokens discovered from tokenizer.json (not hardcoded IDs)
+ * - Byte fallback tokens: <0xNN> for unknown bytes
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <stdint.h>
+#include "iris_kernels.h"
+
+/* ========================================================================
+ * Configuration
+ * ======================================================================== */
+
+#define MISTRAL_MAX_TOKEN_LEN 256
+#define MISTRAL_MAX_SEQ_LEN   512
+#define MISTRAL_HASH_SIZE     300007  /* Prime > 2 * max vocab_size */
+
+/* Default special token IDs (overridden from tokenizer.json if found) */
+#define MISTRAL_DEFAULT_BOS_ID  1
+#define MISTRAL_DEFAULT_EOS_ID  2
+#define MISTRAL_DEFAULT_PAD_ID  0
+
+/* ========================================================================
+ * Data Structures
+ * ======================================================================== */
+
+typedef struct {
+    char *token;
+    int id;
+} mistral_vocab_entry_t;
+
+typedef struct {
+    char *left;
+    char *right;
+    int rank;
+} mistral_bpe_merge_t;
+
+typedef struct mistral_tokenizer {
+    /* Vocabulary: id -> token string */
+    char **vocab;
+    int vocab_size;
+
+    /* Hash table: token string -> id */
+    mistral_vocab_entry_t *vocab_hash;
+    int hash_size;
+
+    /* BPE merges */
+    mistral_bpe_merge_t *merges;
+    int num_merges;
+
+    /* Merge rank lookup hash table */
+    int *merge_ranks;
+
+    /* Special token IDs (discovered from tokenizer.json) */
+    int bos_id;
+    int eos_id;
+    int pad_id;
+    int inst_start_id;  /* [INST] token, or -1 if not found */
+    int inst_end_id;    /* [/INST] token, or -1 if not found */
+
+    /* Whether to use GPT-2 byte encoding (0=raw UTF-8, 1=byte-to-unicode) */
+    int use_byte_encoding;
+} mistral_tokenizer_t;
+
+/* ========================================================================
+ * Byte-Level BPE Encoding Table (GPT-2 style, optional for some tokenizers)
+ * ======================================================================== */
+
+static int mistral_byte_to_unicode[256];
+static int mistral_unicode_to_byte[512];
+static int mistral_byte_encoder_initialized = 0;
+
+static void mistral_init_byte_encoder(void) {
+    if (mistral_byte_encoder_initialized) return;
+
+    for (int i = 33; i <= 126; i++) {
+        mistral_byte_to_unicode[i] = i;
+        mistral_unicode_to_byte[i] = i;
+    }
+    for (int i = 161; i <= 172; i++) {
+        mistral_byte_to_unicode[i] = i;
+        mistral_unicode_to_byte[i] = i;
+    }
+    for (int i = 174; i <= 255; i++) {
+        mistral_byte_to_unicode[i] = i;
+        mistral_unicode_to_byte[i] = i;
+    }
+
+    int offset = 256;
+    for (int i = 0; i < 256; i++) {
+        if (mistral_byte_to_unicode[i] == 0 && i != 33) {
+            mistral_byte_to_unicode[i] = offset;
+            mistral_unicode_to_byte[offset] = i;
+            offset++;
+        }
+    }
+    mistral_byte_to_unicode[0] = 256;
+    mistral_unicode_to_byte[256] = 0;
+
+    mistral_byte_encoder_initialized = 1;
+}
+
+static int mistral_encode_byte_to_utf8(unsigned char b, char *out) {
+    mistral_init_byte_encoder();
+    int cp = mistral_byte_to_unicode[b];
+    if (cp < 128) {
+        out[0] = (char)cp;
+        return 1;
+    } else if (cp < 2048) {
+        out[0] = (char)(0xC0 | (cp >> 6));
+        out[1] = (char)(0x80 | (cp & 0x3F));
+        return 2;
+    }
+    out[0] = '?';
+    return 1;
+}
+
+/* ========================================================================
+ * Hash Functions
+ * ======================================================================== */
+
+static unsigned int mistral_hash_string(const char *str) {
+    unsigned int hash = 2166136261u;
+    while (*str) {
+        hash ^= (unsigned char)*str++;
+        hash *= 16777619u;
+    }
+    return hash;
+}
+
+static void mistral_vocab_hash_insert(mistral_vocab_entry_t *table, int hash_size,
+                                       const char *token, int id) {
+    unsigned int h = mistral_hash_string(token) % hash_size;
+    int probes = 0;
+    while (table[h].token != NULL && probes < hash_size) {
+        if (strcmp(table[h].token, token) == 0) return;
+        h = (h + 1) % hash_size;
+        probes++;
+    }
+    if (probes < hash_size) {
+        table[h].token = strdup(token);
+        table[h].id = id;
+    }
+}
+
+static int mistral_vocab_hash_lookup(const mistral_vocab_entry_t *table, int hash_size,
+                                      const char *token) {
+    unsigned int h = mistral_hash_string(token) % hash_size;
+    int probes = 0;
+    while (table[h].token != NULL && probes < hash_size) {
+        if (strcmp(table[h].token, token) == 0) return table[h].id;
+        h = (h + 1) % hash_size;
+        probes++;
+    }
+    return -1;
+}
+
+/* ========================================================================
+ * JSON Parsing Helpers
+ * ======================================================================== */
+
+static const char *mistral_skip_ws(const char *p) {
+    while (*p && (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')) p++;
+    return p;
+}
+
+static char *mistral_parse_json_string(const char **pp) {
+    const char *p = *pp;
+    if (*p != '"') return NULL;
+    p++;
+
+    const char *start = p;
+    int len = 0;
+    while (*p && *p != '"') {
+        if (*p == '\\' && p[1]) { p += 2; len++; }
+        else { p++; len++; }
+    }
+
+    char *result = malloc(len + 1);
+    if (!result) return NULL;
+
+    p = start;
+    int i = 0;
+    while (*p && *p != '"') {
+        if (*p == '\\' && p[1]) {
+            p++;
+            switch (*p) {
+                case 'n': result[i++] = '\n'; break;
+                case 'r': result[i++] = '\r'; break;
+                case 't': result[i++] = '\t'; break;
+                case '\\': result[i++] = '\\'; break;
+                case '"': result[i++] = '"'; break;
+                case 'u': {
+                    if (p[1] && p[2] && p[3] && p[4]) {
+                        char hex[5] = {p[1], p[2], p[3], p[4], 0};
+                        int cp = (int)strtol(hex, NULL, 16);
+                        p += 4;
+                        if (cp < 0x80) {
+                            result[i++] = (char)cp;
+                        } else if (cp < 0x800) {
+                            result[i++] = (char)(0xC0 | (cp >> 6));
+                            result[i++] = (char)(0x80 | (cp & 0x3F));
+                            len++;
+                        } else {
+                            result[i++] = (char)(0xE0 | (cp >> 12));
+                            result[i++] = (char)(0x80 | ((cp >> 6) & 0x3F));
+                            result[i++] = (char)(0x80 | (cp & 0x3F));
+                            len += 2;
+                        }
+                    }
+                    break;
+                }
+                default: result[i++] = *p; break;
+            }
+            p++;
+        } else {
+            result[i++] = *p++;
+        }
+    }
+    result[i] = '\0';
+
+    if (*p == '"') p++;
+    *pp = p;
+    return result;
+}
+
+static int mistral_parse_json_int(const char **pp) {
+    const char *p = *pp;
+    int neg = 0;
+    if (*p == '-') { neg = 1; p++; }
+    int val = 0;
+    while (*p >= '0' && *p <= '9') {
+        val = val * 10 + (*p - '0');
+        p++;
+    }
+    *pp = p;
+    return neg ? -val : val;
+}
+
+static const char *mistral_skip_json_value(const char *p) {
+    p = mistral_skip_ws(p);
+    if (*p == '"') {
+        p++;
+        while (*p && *p != '"') {
+            if (*p == '\\' && p[1]) p += 2;
+            else p++;
+        }
+        if (*p == '"') p++;
+    } else if (*p == '{') {
+        int depth = 1; p++;
+        while (*p && depth > 0) {
+            if (*p == '{') depth++;
+            else if (*p == '}') depth--;
+            else if (*p == '"') {
+                p++;
+                while (*p && *p != '"') {
+                    if (*p == '\\' && p[1]) p += 2;
+                    else p++;
+                }
+            }
+            p++;
+        }
+    } else if (*p == '[') {
+        int depth = 1; p++;
+        while (*p && depth > 0) {
+            if (*p == '[') depth++;
+            else if (*p == ']') depth--;
+            else if (*p == '"') {
+                p++;
+                while (*p && *p != '"') {
+                    if (*p == '\\' && p[1]) p += 2;
+                    else p++;
+                }
+            }
+            p++;
+        }
+    } else {
+        while (*p && *p != ',' && *p != '}' && *p != ']' &&
+               *p != ' ' && *p != '\n' && *p != '\r' && *p != '\t') p++;
+    }
+    return p;
+}
+
+/* ========================================================================
+ * Tokenizer Loading
+ * ======================================================================== */
+
+mistral_tokenizer_t *mistral_tokenizer_load(const char *tokenizer_json_path) {
+    FILE *f = fopen(tokenizer_json_path, "rb");
+    if (!f) {
+        fprintf(stderr, "mistral_tokenizer_load: cannot open %s\n", tokenizer_json_path);
+        return NULL;
+    }
+
+    fseek(f, 0, SEEK_END);
+    long size = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    char *json = malloc(size + 1);
+    if (!json) { fclose(f); return NULL; }
+    fread(json, 1, size, f);
+    json[size] = '\0';
+    fclose(f);
+
+    mistral_tokenizer_t *tok = calloc(1, sizeof(mistral_tokenizer_t));
+    if (!tok) { free(json); return NULL; }
+
+    tok->hash_size = MISTRAL_HASH_SIZE;
+    tok->vocab_hash = calloc(tok->hash_size, sizeof(mistral_vocab_entry_t));
+    if (!tok->vocab_hash) { free(tok); free(json); return NULL; }
+
+    /* Set default special token IDs */
+    tok->bos_id = MISTRAL_DEFAULT_BOS_ID;
+    tok->eos_id = MISTRAL_DEFAULT_EOS_ID;
+    tok->pad_id = MISTRAL_DEFAULT_PAD_ID;
+    tok->inst_start_id = -1;
+    tok->inst_end_id = -1;
+
+    /* Detect byte encoding mode from pre_tokenizer.
+     * If "ByteLevel" is found → GPT-2 style byte encoding.
+     * If "ByteFallback" is found → raw UTF-8 with byte fallback. */
+    tok->use_byte_encoding = 0;
+    if (strstr(json, "\"ByteLevel\"")) {
+        tok->use_byte_encoding = 1;
+    }
+
+    /* Parse vocabulary from "model": { "vocab": { ... } } */
+    const char *p = strstr(json, "\"model\"");
+    if (!p) {
+        fprintf(stderr, "mistral_tokenizer_load: no model section\n");
+        goto error;
+    }
+
+    p = strstr(p, "\"vocab\"");
+    if (!p) {
+        fprintf(stderr, "mistral_tokenizer_load: no vocab section\n");
+        goto error;
+    }
+
+    p = strchr(p, '{');
+    if (!p) goto error;
+    p++;
+
+    /* Count vocab entries */
+    int vocab_count = 0;
+    const char *count_p = p;
+    int depth = 1;
+    while (*count_p && depth > 0) {
+        if (*count_p == '{') depth++;
+        else if (*count_p == '}') depth--;
+        else if (*count_p == '"' && depth == 1) {
+            vocab_count++;
+            count_p++;
+            while (*count_p && *count_p != '"') {
+                if (*count_p == '\\' && count_p[1]) count_p += 2;
+                else count_p++;
+            }
+        }
+        count_p++;
+    }
+
+    tok->vocab_size = vocab_count;
+    tok->vocab = calloc(vocab_count + 1000, sizeof(char *));
+    if (!tok->vocab) goto error;
+
+    /* Parse vocab entries */
+    p = mistral_skip_ws(p);
+    int max_id = 0;
+    while (*p && *p != '}') {
+        if (*p == '"') {
+            char *token = mistral_parse_json_string(&p);
+            p = mistral_skip_ws(p);
+            if (*p == ':') p++;
+            p = mistral_skip_ws(p);
+            int id = mistral_parse_json_int(&p);
+
+            if (token && id >= 0 && id < vocab_count + 1000) {
+                tok->vocab[id] = token;
+                mistral_vocab_hash_insert(tok->vocab_hash, tok->hash_size, token, id);
+                if (id > max_id) max_id = id;
+            } else {
+                free(token);
+            }
+
+            p = mistral_skip_ws(p);
+            if (*p == ',') p++;
+            p = mistral_skip_ws(p);
+        } else {
+            p++;
+        }
+    }
+
+    /* Parse merges from "model": { "merges": [ ... ] } */
+    p = strstr(json, "\"merges\"");
+    if (!p) {
+        fprintf(stderr, "mistral_tokenizer_load: no merges section\n");
+        goto error;
+    }
+
+    p = strchr(p, '[');
+    if (!p) goto error;
+    p++;
+
+    /* Count merges */
+    int merge_count = 0;
+    count_p = p;
+    depth = 1;
+    while (*count_p && depth > 0) {
+        if (*count_p == '[') {
+            if (depth == 1) merge_count++;
+            depth++;
+        } else if (*count_p == ']') {
+            depth--;
+        } else if (*count_p == '"') {
+            count_p++;
+            while (*count_p && *count_p != '"') {
+                if (*count_p == '\\' && count_p[1]) count_p += 2;
+                else count_p++;
+            }
+        }
+        if (*count_p) count_p++;
+    }
+
+    tok->num_merges = merge_count;
+    tok->merges = calloc(merge_count, sizeof(mistral_bpe_merge_t));
+    tok->merge_ranks = calloc(tok->hash_size, sizeof(int));
+    if (!tok->merges || !tok->merge_ranks) goto error;
+
+    for (int i = 0; i < tok->hash_size; i++) {
+        tok->merge_ranks[i] = -1;
+    }
+
+    /* Parse merges */
+    p = mistral_skip_ws(p);
+    int merge_idx = 0;
+    while (*p && *p != ']' && merge_idx < merge_count) {
+        if (*p == '[') {
+            p++;
+            p = mistral_skip_ws(p);
+
+            char *left = NULL, *right = NULL;
+            if (*p == '"') left = mistral_parse_json_string(&p);
+            p = mistral_skip_ws(p);
+            if (*p == ',') p++;
+            p = mistral_skip_ws(p);
+            if (*p == '"') right = mistral_parse_json_string(&p);
+
+            while (*p && *p != ']') p++;
+            if (*p == ']') p++;
+
+            if (left && right) {
+                tok->merges[merge_idx].left = left;
+                tok->merges[merge_idx].right = right;
+                tok->merges[merge_idx].rank = merge_idx;
+
+                int len1 = strlen(left);
+                int len2 = strlen(right);
+                char *key = malloc(len1 + len2 + 2);
+                memcpy(key, left, len1);
+                key[len1] = ' ';
+                memcpy(key + len1 + 1, right, len2);
+                key[len1 + len2 + 1] = '\0';
+
+                unsigned int h = mistral_hash_string(key) % tok->hash_size;
+                int probes = 0;
+                while (tok->merge_ranks[h] != -1 && probes < tok->hash_size) {
+                    h = (h + 1) % tok->hash_size;
+                    probes++;
+                }
+                if (probes < tok->hash_size) {
+                    tok->merge_ranks[h] = merge_idx;
+                }
+                free(key);
+            } else {
+                free(left);
+                free(right);
+            }
+
+            merge_idx++;
+            p = mistral_skip_ws(p);
+            if (*p == ',') p++;
+            p = mistral_skip_ws(p);
+        } else {
+            p++;
+        }
+    }
+
+    /* Parse added_tokens for special tokens */
+    p = strstr(json, "\"added_tokens\"");
+    if (p) {
+        p = strchr(p, '[');
+        if (p) {
+            p++;
+            while (*p && *p != ']') {
+                if (*p == '{') {
+                    p++;
+                    char *content = NULL;
+                    int id = -1;
+
+                    while (*p && *p != '}') {
+                        p = mistral_skip_ws(p);
+                        if (*p == '"') {
+                            char *key = mistral_parse_json_string(&p);
+                            p = mistral_skip_ws(p);
+                            if (*p == ':') p++;
+                            p = mistral_skip_ws(p);
+
+                            if (key && strcmp(key, "content") == 0 && *p == '"') {
+                                content = mistral_parse_json_string(&p);
+                            } else if (key && strcmp(key, "id") == 0) {
+                                id = mistral_parse_json_int(&p);
+                            } else {
+                                p = mistral_skip_json_value(p);
+                            }
+                            free(key);
+                        }
+                        p = mistral_skip_ws(p);
+                        if (*p == ',') p++;
+                    }
+
+                    if (content && id >= 0) {
+                        if (id < vocab_count + 1000) {
+                            if (!tok->vocab[id]) {
+                                tok->vocab[id] = content;
+                                mistral_vocab_hash_insert(tok->vocab_hash, tok->hash_size, content, id);
+                                if (id > max_id) max_id = id;
+                                content = NULL;
+                            }
+                        }
+
+                        /* Detect known special tokens */
+                        if (content) {
+                            if (strcmp(content, "<s>") == 0) tok->bos_id = id;
+                            else if (strcmp(content, "</s>") == 0) tok->eos_id = id;
+                            else if (strcmp(content, "[INST]") == 0) tok->inst_start_id = id;
+                            else if (strcmp(content, "[/INST]") == 0) tok->inst_end_id = id;
+                        } else {
+                            /* content was moved to vocab, check from vocab */
+                            const char *v = tok->vocab[id];
+                            if (v) {
+                                if (strcmp(v, "<s>") == 0) tok->bos_id = id;
+                                else if (strcmp(v, "</s>") == 0) tok->eos_id = id;
+                                else if (strcmp(v, "[INST]") == 0) tok->inst_start_id = id;
+                                else if (strcmp(v, "[/INST]") == 0) tok->inst_end_id = id;
+                            }
+                        }
+                    }
+                    free(content);
+
+                    if (*p == '}') p++;
+                }
+                p = mistral_skip_ws(p);
+                if (*p == ',') p++;
+            }
+        }
+    }
+
+    tok->vocab_size = max_id + 1;
+
+    free(json);
+
+    if (iris_verbose)
+        fprintf(stderr, " Mistral tokenizer loaded (%d vocab, bos=%d, eos=%d, byte_enc=%d)\n",
+                tok->vocab_size, tok->bos_id, tok->eos_id, tok->use_byte_encoding);
+
+    return tok;
+
+error:
+    free(json);
+    if (tok) {
+        free(tok->vocab_hash);
+        free(tok->vocab);
+        free(tok->merges);
+        free(tok->merge_ranks);
+        free(tok);
+    }
+    return NULL;
+}
+
+void mistral_tokenizer_free(mistral_tokenizer_t *tok) {
+    if (!tok) return;
+
+    if (tok->vocab) {
+        for (int i = 0; i < tok->vocab_size; i++) free(tok->vocab[i]);
+        free(tok->vocab);
+    }
+
+    if (tok->vocab_hash) {
+        for (int i = 0; i < tok->hash_size; i++) free(tok->vocab_hash[i].token);
+        free(tok->vocab_hash);
+    }
+
+    if (tok->merges) {
+        for (int i = 0; i < tok->num_merges; i++) {
+            free(tok->merges[i].left);
+            free(tok->merges[i].right);
+        }
+        free(tok->merges);
+    }
+
+    free(tok->merge_ranks);
+    free(tok);
+}
+
+/* ========================================================================
+ * Merge Rank Lookup
+ * ======================================================================== */
+
+static int mistral_get_merge_rank(mistral_tokenizer_t *tok, const char *left, const char *right) {
+    int len1 = strlen(left);
+    int len2 = strlen(right);
+    char *key = malloc(len1 + len2 + 2);
+    if (!key) return -1;
+    memcpy(key, left, len1);
+    key[len1] = ' ';
+    memcpy(key + len1 + 1, right, len2);
+    key[len1 + len2 + 1] = '\0';
+
+    unsigned int h = mistral_hash_string(key) % tok->hash_size;
+    int probes = 0;
+    while (tok->merge_ranks[h] != -1 && probes < tok->hash_size) {
+        int rank = tok->merge_ranks[h];
+        if (rank >= 0 && rank < tok->num_merges) {
+            if (strcmp(tok->merges[rank].left, left) == 0 &&
+                strcmp(tok->merges[rank].right, right) == 0) {
+                free(key);
+                return rank;
+            }
+        }
+        h = (h + 1) % tok->hash_size;
+        probes++;
+    }
+
+    free(key);
+    return -1;
+}
+
+/* ========================================================================
+ * BPE Tokenization
+ * ======================================================================== */
+
+typedef struct mistral_token_node {
+    char *text;
+    struct mistral_token_node *next;
+} mistral_token_node_t;
+
+static mistral_token_node_t *mistral_create_node(const char *text) {
+    mistral_token_node_t *node = malloc(sizeof(mistral_token_node_t));
+    if (node) {
+        node->text = strdup(text);
+        node->next = NULL;
+    }
+    return node;
+}
+
+static void mistral_free_token_list(mistral_token_node_t *head) {
+    while (head) {
+        mistral_token_node_t *next = head->next;
+        free(head->text);
+        free(head);
+        head = next;
+    }
+}
+
+static mistral_token_node_t *mistral_bpe_encode_word(mistral_tokenizer_t *tok, const char *word) {
+    int len = strlen(word);
+    if (len == 0) return NULL;
+
+    /* Start with character-level tokens */
+    mistral_token_node_t *head = NULL;
+    mistral_token_node_t *tail = NULL;
+
+    const char *p = word;
+    while (*p) {
+        int char_len = 1;
+        unsigned char c = (unsigned char)*p;
+        if ((c & 0xE0) == 0xC0) char_len = 2;
+        else if ((c & 0xF0) == 0xE0) char_len = 3;
+        else if ((c & 0xF8) == 0xF0) char_len = 4;
+
+        char buf[8];
+        memcpy(buf, p, char_len);
+        buf[char_len] = '\0';
+
+        mistral_token_node_t *node = mistral_create_node(buf);
+        if (!head) head = node;
+        else tail->next = node;
+        tail = node;
+
+        p += char_len;
+    }
+
+    /* Apply BPE merges */
+    int changed = 1;
+    while (changed) {
+        changed = 0;
+
+        int best_rank = tok->num_merges + 1;
+        mistral_token_node_t *best_node = NULL;
+
+        for (mistral_token_node_t *node = head; node && node->next; node = node->next) {
+            int rank = mistral_get_merge_rank(tok, node->text, node->next->text);
+            if (rank >= 0 && rank < best_rank) {
+                best_rank = rank;
+                best_node = node;
+            }
+        }
+
+        if (best_node) {
+            int len1 = strlen(best_node->text);
+            int len2 = strlen(best_node->next->text);
+            char *merged = malloc(len1 + len2 + 1);
+            memcpy(merged, best_node->text, len1);
+            memcpy(merged + len1, best_node->next->text, len2);
+            merged[len1 + len2] = '\0';
+
+            free(best_node->text);
+            best_node->text = merged;
+
+            mistral_token_node_t *to_free = best_node->next;
+            best_node->next = to_free->next;
+            free(to_free->text);
+            free(to_free);
+
+            changed = 1;
+        }
+    }
+
+    return head;
+}
+
+/* Convert text to byte-level encoding (only used when use_byte_encoding=1) */
+static char *mistral_text_to_bytes(const char *text) {
+    mistral_init_byte_encoder();
+    int len = strlen(text);
+    char *result = malloc(len * 2 + 1);
+    if (!result) return NULL;
+
+    int j = 0;
+    for (int i = 0; i < len; i++) {
+        j += mistral_encode_byte_to_utf8((unsigned char)text[i], result + j);
+    }
+    result[j] = '\0';
+    return result;
+}
+
+/* ========================================================================
+ * Pre-tokenization
+ * ======================================================================== */
+
+static char **mistral_pretokenize(const char *text, int *num_chunks) {
+    int capacity = 64;
+    char **chunks = malloc(capacity * sizeof(char *));
+    int count = 0;
+
+    const char *p = text;
+    while (*p) {
+        const char *start = p;
+
+        if (*p == '\'' && p[1]) {
+            char lower = tolower(p[1]);
+            if (lower == 's' || lower == 't' || lower == 'm' || lower == 'd') {
+                p += 2;
+            } else if ((lower == 'r' || lower == 'v' || lower == 'l') && p[2] &&
+                       (tolower(p[2]) == 'e' || tolower(p[2]) == 'l')) {
+                p += 3;
+            } else {
+                p++;
+            }
+        }
+        else if ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+                 (unsigned char)*p >= 128) {
+            while (*p && ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+                          (unsigned char)*p >= 128)) {
+                if ((unsigned char)*p >= 128) {
+                    if (((unsigned char)*p & 0xE0) == 0xC0) p += 2;
+                    else if (((unsigned char)*p & 0xF0) == 0xE0) p += 3;
+                    else if (((unsigned char)*p & 0xF8) == 0xF0) p += 4;
+                    else p++;
+                } else {
+                    p++;
+                }
+            }
+        }
+        else if (*p >= '0' && *p <= '9') {
+            while (*p >= '0' && *p <= '9') p++;
+        }
+        else if (*p == ' ' && p[1] && (isalpha(p[1]) || (unsigned char)p[1] >= 128)) {
+            p++;
+            while (*p && ((*p >= 'a' && *p <= 'z') || (*p >= 'A' && *p <= 'Z') ||
+                          (unsigned char)*p >= 128)) {
+                if ((unsigned char)*p >= 128) {
+                    if (((unsigned char)*p & 0xE0) == 0xC0) p += 2;
+                    else if (((unsigned char)*p & 0xF0) == 0xE0) p += 3;
+                    else if (((unsigned char)*p & 0xF8) == 0xF0) p += 4;
+                    else p++;
+                } else {
+                    p++;
+                }
+            }
+        }
+        else if (*p == ' ' && p[1] >= '0' && p[1] <= '9') {
+            p++;
+            while (*p >= '0' && *p <= '9') p++;
+        }
+        else if (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t') {
+            while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t') p++;
+        }
+        else {
+            p++;
+        }
+
+        if (p > start) {
+            int len = p - start;
+            char *chunk = malloc(len + 1);
+            memcpy(chunk, start, len);
+            chunk[len] = '\0';
+
+            if (count >= capacity) {
+                capacity *= 2;
+                chunks = realloc(chunks, capacity * sizeof(char *));
+            }
+            chunks[count++] = chunk;
+        }
+    }
+
+    *num_chunks = count;
+    return chunks;
+}
+
+/* ========================================================================
+ * Main Tokenization API
+ * ======================================================================== */
+
+static int *mistral_tokenize(mistral_tokenizer_t *tok, const char *text,
+                              int *num_tokens, int max_len) {
+    if (max_len <= 0) max_len = MISTRAL_MAX_SEQ_LEN;
+
+    int num_chunks;
+    char **chunks = mistral_pretokenize(text, &num_chunks);
+
+    int capacity = 256;
+    int *tokens = malloc(capacity * sizeof(int));
+    int total = 0;
+
+    for (int c = 0; c < num_chunks && total < max_len; c++) {
+        char *input_text;
+        if (tok->use_byte_encoding) {
+            input_text = mistral_text_to_bytes(chunks[c]);
+        } else {
+            input_text = strdup(chunks[c]);
+        }
+        if (!input_text) { free(chunks[c]); continue; }
+
+        mistral_token_node_t *bpe_tokens = mistral_bpe_encode_word(tok, input_text);
+
+        for (mistral_token_node_t *node = bpe_tokens; node && total < max_len; node = node->next) {
+            int id = mistral_vocab_hash_lookup(tok->vocab_hash, tok->hash_size, node->text);
+            if (id >= 0) {
+                if (total >= capacity) {
+                    capacity *= 2;
+                    tokens = realloc(tokens, capacity * sizeof(int));
+                }
+                tokens[total++] = id;
+            }
+            /* TODO: byte fallback for unknown tokens (<0xNN>) */
+        }
+
+        mistral_free_token_list(bpe_tokens);
+        free(input_text);
+        free(chunks[c]);
+    }
+    free(chunks);
+
+    *num_tokens = total;
+    return tokens;
+}
+
+/* Tokenize with Mistral chat template for FLUX.2-dev.
+ * Format: <s>[INST] {prompt} [/INST] */
+int *mistral_tokenize_chat(mistral_tokenizer_t *tok, const char *prompt,
+                           int *num_tokens, int max_len) {
+    if (max_len <= 0) max_len = MISTRAL_MAX_SEQ_LEN;
+
+    int capacity = 256;
+    int *tokens = malloc(capacity * sizeof(int));
+    int total = 0;
+
+    /* BOS token */
+    tokens[total++] = tok->bos_id;
+
+    /* [INST] token */
+    if (tok->inst_start_id >= 0) {
+        tokens[total++] = tok->inst_start_id;
+    } else {
+        /* Tokenize [INST] as text */
+        int n;
+        int *inst_tokens = mistral_tokenize(tok, "[INST]", &n, max_len - total);
+        for (int i = 0; i < n && total < max_len; i++) {
+            if (total >= capacity) { capacity *= 2; tokens = realloc(tokens, capacity * sizeof(int)); }
+            tokens[total++] = inst_tokens[i];
+        }
+        free(inst_tokens);
+    }
+
+    /* Space + prompt */
+    {
+        /* Prepend space to prompt for proper tokenization */
+        int prompt_len = strlen(prompt);
+        char *spaced_prompt = malloc(prompt_len + 2);
+        spaced_prompt[0] = ' ';
+        memcpy(spaced_prompt + 1, prompt, prompt_len + 1);
+
+        int n;
+        int *prompt_tokens = mistral_tokenize(tok, spaced_prompt, &n, max_len - total);
+        for (int i = 0; i < n && total < max_len; i++) {
+            if (total >= capacity) { capacity *= 2; tokens = realloc(tokens, capacity * sizeof(int)); }
+            tokens[total++] = prompt_tokens[i];
+        }
+        free(prompt_tokens);
+        free(spaced_prompt);
+    }
+
+    /* Space + [/INST] */
+    if (tok->inst_end_id >= 0) {
+        /* Tokenize the space before [/INST] */
+        int n;
+        int *space_tokens = mistral_tokenize(tok, " ", &n, max_len - total);
+        for (int i = 0; i < n && total < max_len; i++) {
+            if (total >= capacity) { capacity *= 2; tokens = realloc(tokens, capacity * sizeof(int)); }
+            tokens[total++] = space_tokens[i];
+        }
+        free(space_tokens);
+
+        if (total < max_len) {
+            if (total >= capacity) { capacity *= 2; tokens = realloc(tokens, capacity * sizeof(int)); }
+            tokens[total++] = tok->inst_end_id;
+        }
+    } else {
+        int n;
+        int *inst_tokens = mistral_tokenize(tok, " [/INST]", &n, max_len - total);
+        for (int i = 0; i < n && total < max_len; i++) {
+            if (total >= capacity) { capacity *= 2; tokens = realloc(tokens, capacity * sizeof(int)); }
+            tokens[total++] = inst_tokens[i];
+        }
+        free(inst_tokens);
+    }
+
+    *num_tokens = total;
+    return tokens;
+}
+
+int *mistral_pad_tokens(int *tokens, int num_tokens, int max_len, int *attention_mask) {
+    int *padded = malloc(max_len * sizeof(int));
+    if (!padded) return NULL;
+
+    for (int i = 0; i < max_len; i++) {
+        if (i < num_tokens) {
+            padded[i] = tokens[i];
+            if (attention_mask) attention_mask[i] = 1;
+        } else {
+            padded[i] = MISTRAL_DEFAULT_PAD_ID;
+            if (attention_mask) attention_mask[i] = 0;
+        }
+    }
+
+    return padded;
+}
+
+const char *mistral_get_token(mistral_tokenizer_t *tok, int id) {
+    if (!tok || id < 0 || id >= tok->vocab_size) return NULL;
+    return tok->vocab[id];
+}


### PR DESCRIPTION
## Summary

- Adds full FLUX.2-dev (32B) inference support using Mistral-Small-3.2-24B as text encoder (layers 10/20/30, 15360-dim output + pooled embedding)
- Guidance-distilled: embeds guidance scale directly in transformer (no CFG needed), default 30 steps with guidance 3.5
- Auto-detected from transformer config (`guidance_embeds: true`)

### New files
- `iris_mistral.c/h` — Mistral-Small-3.2-24B encoder implementation
- `iris_mistral_tokenizer.c` — Mistral BPE tokenizer (SentencePiece-style)

### Transformer changes
- Guidance and text pooled embedders (`time_text_embed.*` weight naming)
- Tensor name fallback chain for dev vs klein weight files
- Chunked attention for large sequences (keeps GPU score matrix small)
- Multiref RoPE caching across denoising steps
- BF16/F16 warmup dispatch for M1/M2 vs M3+ hardware

### Other changes
- Batch generation mode (`-N` flag) and `--step-dir` for file-based step previews
- SDPA forward declaration for macOS 14 SDK compatibility
- README documentation (architecture, download, memory, usage)

## Test plan

- [ ] Build with `make mps` / `make blas`
- [ ] Run with existing Klein 4B model (regression test)
- [ ] Download FLUX.2-dev weights and run: `./iris -d flux-2-dev -p "a cat" -o /tmp/test.png`
- [ ] Verify auto-detection works from model config
- [ ] Test batch mode: `./iris -d flux-klein-4b -p "a cat" -N 3 -o /tmp/batch.png`