### PR TITLE
Release work buffers after sampling and scale references to ~1MP

### DIFF
--- a/iris.c
+++ b/iris.c
@@ -40,6 +40,7 @@ extern iris_vae_t *iris_vae_load_safetensors_ex(safetensors_file_t *sf,
                                                   float scaling_factor,
                                                   float shift_factor);
 extern void iris_vae_free(iris_vae_t *vae);
+extern void iris_vae_release_work_memory(iris_vae_t *vae);
 extern float *iris_vae_encode(iris_vae_t *vae, const float *img,
                               int batch, int H, int W, int *out_h, int *out_w);
 extern iris_image *iris_vae_decode(iris_vae_t *vae, const float *latent,
@@ -50,6 +51,7 @@ extern iris_transformer_flux_t *iris_transformer_load_flux(FILE *f);
 extern iris_transformer_flux_t *iris_transformer_load_safetensors_flux(const char *model_dir);
 extern iris_transformer_flux_t *iris_transformer_load_safetensors_mmap_flux(const char *model_dir);
 extern void iris_transformer_free_flux(iris_transformer_flux_t *tf);
+extern void iris_transformer_release_work_memory_flux(iris_transformer_flux_t *tf);
 extern float *iris_transformer_forward_flux(iris_transformer_flux_t *tf,
                                         const float *img_latent, int img_h, int img_w,
                                         const float *txt_emb, int txt_seq,
@@ -876,6 +878,9 @@ iris_image *iris_generate(iris_ctx *ctx, const char *prompt,
         );
     }
 
+    /* Release work buffers after sampling */
+    iris_transformer_release_work_memory_flux(ctx->transformer);
+
     free(z);
     free(schedule);
     free(text_emb);
@@ -1097,6 +1102,29 @@ iris_image *iris_generate_with_embeddings_and_noise(iris_ctx *ctx,
 }
 
 /* ========================================================================
+ * Reference Image Scaling
+ * ======================================================================== */
+
+/* Scale reference dimensions to fit within a pixel budget, preserving aspect ratio.
+ * Dimensions are rounded down to multiples of 16, clamped to [16, IRIS_VAE_MAX_DIM].
+ * FLUX models are trained at ~1MP buckets (1024x1024, 768x1344, etc.), so references
+ * beyond that extrapolate RoPE positions and degrade quality. */
+static void fit_ref_to_pixel_budget(int *ref_h, int *ref_w, int max_pixels) {
+    int h = *ref_h, w = *ref_w;
+    if ((long)h * w > max_pixels) {
+        float scale = sqrtf((float)max_pixels / ((float)h * w));
+        h = (int)(h * scale) / 16 * 16;
+        w = (int)(w * scale) / 16 * 16;
+    }
+    if (h > IRIS_VAE_MAX_DIM) h = IRIS_VAE_MAX_DIM;
+    if (w > IRIS_VAE_MAX_DIM) w = IRIS_VAE_MAX_DIM;
+    if (h < 16) h = 16;
+    if (w < 16) w = 16;
+    *ref_h = h;
+    *ref_w = w;
+}
+
+/* ========================================================================
  * Attention Memory Budget
  * ======================================================================== */
 
@@ -1207,15 +1235,22 @@ iris_image *iris_img2img(iris_ctx *ctx, const char *prompt,
     p.width = (p.width / 16) * 16;
     p.height = (p.height / 16) * 16;
 
+    /* Scale reference to ~1MP pixel budget (matches training resolution),
+     * preserving aspect ratio. This replaces the old per-axis clamping that
+     * would squash a 3984x5312 image to 1792x1792 (losing aspect ratio and
+     * extrapolating far beyond trained RoPE positions). */
+    int ref_h = (input->height / 16) * 16;
+    int ref_w = (input->width / 16) * 16;
+    fit_ref_to_pixel_budget(&ref_h, &ref_w, IRIS_REF_MAX_PIXELS);
+
     /* Check attention memory budget — shrink reference if needed. */
-    int ref_w = p.width, ref_h = p.height;
     {
-        int ref_dims[2] = { p.height, p.width };
+        int ref_dims[2] = { ref_h, ref_w };
         if (fit_refs_for_attention(ctx->num_heads, p.height, p.width,
                                     ref_dims, 1, IRIS_MAX_SEQ_LEN)) {
             fprintf(stderr, "Note: reference image resized from %dx%d to %dx%d "
                     "(GPU attention memory limit)\n",
-                    p.width, p.height, ref_dims[1], ref_dims[0]);
+                    ref_w, ref_h, ref_dims[1], ref_dims[0]);
             ref_h = ref_dims[0];
             ref_w = ref_dims[1];
         }
@@ -1288,6 +1323,8 @@ iris_image *iris_img2img(iris_ctx *ctx, const char *prompt,
     }
 
     free(img_tensor);
+    /* Release VAE work buffer pages — encoding is done, decode will lazy-refault */
+    iris_vae_release_work_memory(ctx->vae);
     if (iris_phase_callback) iris_phase_callback("encoding reference image", 1);
 
     if (!img_latent) {
@@ -1348,6 +1385,9 @@ iris_image *iris_img2img(iris_ctx *ctx, const char *prompt,
             NULL
         );
     }
+
+    /* Release work buffers after sampling */
+    iris_transformer_release_work_memory_flux(ctx->transformer);
 
     free(z);
     free(img_latent);
@@ -1456,15 +1496,12 @@ iris_image *iris_multiref(iris_ctx *ctx, const char *prompt,
         return NULL;
     }
 
-    /* Build reference pixel dimensions, clamped and rounded to 16. */
+    /* Build reference pixel dimensions, scaled to ~1MP budget and rounded to 16. */
     int *ref_pixel_dims = (int *)malloc(num_refs * 2 * sizeof(int));
     for (int i = 0; i < num_refs; i++) {
         int rh = (refs[i]->height / 16) * 16;
         int rw = (refs[i]->width / 16) * 16;
-        if (rh > IRIS_VAE_MAX_DIM) rh = IRIS_VAE_MAX_DIM;
-        if (rw > IRIS_VAE_MAX_DIM) rw = IRIS_VAE_MAX_DIM;
-        if (rh < 16) rh = 16;
-        if (rw < 16) rw = 16;
+        fit_ref_to_pixel_budget(&rh, &rw, IRIS_REF_MAX_PIXELS);
         ref_pixel_dims[i*2]   = rh;
         ref_pixel_dims[i*2+1] = rw;
     }
@@ -1546,6 +1583,9 @@ iris_image *iris_multiref(iris_ctx *ctx, const char *prompt,
     free(resized_imgs);
     free(ref_pixel_dims);
 
+    /* Release VAE work buffer pages — encoding is done, decode will lazy-refault */
+    iris_vae_release_work_memory(ctx->vae);
+
     int latent_h = p.height / 16;
     int latent_w = p.width / 16;
     int image_seq_len = latent_h * latent_w;
@@ -1577,6 +1617,9 @@ iris_image *iris_multiref(iris_ctx *ctx, const char *prompt,
             NULL
         );
     }
+
+    /* Release work buffers after sampling */
+    iris_transformer_release_work_memory_flux(ctx->transformer);
 
     /* Cleanup */
     free(z);

--- a/iris.h
+++ b/iris.h
@@ -42,6 +42,7 @@ extern "C" {
 #define IRIS_VAE_NUM_RES        2
 #define IRIS_VAE_GROUPS         32
 #define IRIS_VAE_MAX_DIM        1792  /* Max image dimension for VAE */
+#define IRIS_REF_MAX_PIXELS     1048576  /* ~1MP reference pixel budget (matches training) */
 
 /* Tokenizer */
 #define IRIS_MAX_SEQ_LEN        512

--- a/iris_transformer_flux.c
+++ b/iris_transformer_flux.c
@@ -4693,6 +4693,54 @@ void iris_transformer_free_flux(iris_transformer_flux_t *tf) {
     free(tf);
 }
 
+/* Release transformer work buffers between generations.
+ * Frees all dynamically-sized work buffers and resets allocation tracking
+ * so ensure_work_buffers() will re-allocate at the correct size for the
+ * next generation. This prevents large img2img buffers (e.g. 8-10 GB for
+ * a 1792x1792 reference) from persisting when subsequent generations need
+ * much less memory. */
+void iris_transformer_release_work_memory_flux(iris_transformer_flux_t *tf) {
+    if (!tf || tf->work_seq_alloc == 0) return;
+
+    /* Main hidden state buffers */
+    free(tf->img_hidden);   tf->img_hidden = NULL;
+    free(tf->txt_hidden);   tf->txt_hidden = NULL;
+    free(tf->work1);        tf->work1 = NULL;
+    free(tf->work2);        tf->work2 = NULL;
+    tf->work_size = 0;
+
+    /* Attention workspace buffers */
+    free(tf->attn_q_t);     tf->attn_q_t = NULL;
+    free(tf->attn_k_t);     tf->attn_k_t = NULL;
+    free(tf->attn_v_t);     tf->attn_v_t = NULL;
+    free(tf->attn_out_t);   tf->attn_out_t = NULL;
+    free(tf->attn_cat_k);   tf->attn_cat_k = NULL;
+    free(tf->attn_cat_v);   tf->attn_cat_v = NULL;
+
+    /* Attention scores */
+    free(tf->attn_scores);  tf->attn_scores = NULL;
+    tf->attn_scores_alloc = 0;
+
+    /* Single-block work buffers */
+    free(tf->single_q);          tf->single_q = NULL;
+    free(tf->single_k);          tf->single_k = NULL;
+    free(tf->single_v);          tf->single_v = NULL;
+    free(tf->single_mlp_gate);   tf->single_mlp_gate = NULL;
+    free(tf->single_mlp_up);     tf->single_mlp_up = NULL;
+    free(tf->single_attn_out);   tf->single_attn_out = NULL;
+    free(tf->single_concat);     tf->single_concat = NULL;
+
+    /* FFN work buffers */
+    free(tf->ffn_gate);          tf->ffn_gate = NULL;
+    free(tf->ffn_up);            tf->ffn_up = NULL;
+
+    /* Double-block work buffers */
+    free(tf->double_img_attn_out); tf->double_img_attn_out = NULL;
+    free(tf->double_txt_attn_out); tf->double_txt_attn_out = NULL;
+
+    tf->work_seq_alloc = 0;
+}
+
 /* ========================================================================
  * Safetensors Loading
  * ======================================================================== */


### PR DESCRIPTION
## Summary

- **Transformer work buffer release**: After sampling, free all dynamically-sized work buffers (`img_hidden`, `attn_scores`, `single_q/k/v`, etc.) via new `iris_transformer_release_work_memory_flux()`. These buffers grow to fit the largest sequence seen — with a large reference image (e.g. 3984×5312) this can reach 8-10 GB and persists across generations. The next call to `ensure_work_buffers()` re-allocates at the correct smaller size.

- **VAE work buffer release**: Mark VAE work buffer pages as reclaimable via `madvise(MADV_FREE)` after encoding. The OS can reclaim ~18 GB immediately without swapping; pages are lazily zero-filled on next access during decode.

- **Reference image scaling**: Replace per-axis clamping to `IRIS_VAE_MAX_DIM` (1792) with aspect-ratio-preserving scaling to `IRIS_REF_MAX_PIXELS` (1048576 ≈ 1MP). The old approach squashes a 3984×5312 photo to 1792×1792, destroying aspect ratio and extrapolating far beyond trained RoPE positions. The new approach scales proportionally, matching training resolution buckets (1024×1024, 768×1344, etc.).

## Test plan

- [ ] Build with `make mps` / `make blas`
- [ ] txt2img generation (no reference — should work identically)
- [ ] img2img with large reference image — verify aspect ratio preserved and memory drops
- [ ] multiref — verify references scaled proportionally
- [ ] Verify `ensure_work_buffers()` re-allocates correctly for next generation