### PR TITLE
Fix: null-check malloc/realloc in attention, sampling, and tokenizer

### DIFF
--- a/iris.c
+++ b/iris.c
@@ -737,6 +737,11 @@ static iris_image *iris_generate_zimage_with_embeddings(iris_ctx *ctx,
      * where latent_ch = in_ch * ps * ps = 64 */
     int latent_ch = in_ch * ps * ps;
     float *latent = (float *)malloc(latent_ch * post_h * post_w * sizeof(float));
+    if (!latent) {
+        free(denoised);
+        set_error("Out of memory allocating latent");
+        return NULL;
+    }
     iris_patchify(latent, denoised, 1, in_ch, pre_h, pre_w, ps);
     free(denoised);
 
@@ -1058,6 +1063,10 @@ iris_image *iris_generate_with_embeddings_and_noise(iris_ctx *ctx,
 
     /* Copy external noise */
     float *z = (float *)malloc(expected_noise_size * sizeof(float));
+    if (!z) {
+        set_error("Out of memory allocating noise buffer");
+        return NULL;
+    }
     memcpy(z, noise, expected_noise_size * sizeof(float));
 
     /* Get schedule */

--- a/iris_kernels.c
+++ b/iris_kernels.c
@@ -658,6 +658,7 @@ void iris_attention(float *out, const float *Q, const float *K, const float *V,
                     float scale) {
     /* Allocate attention scores */
     float *scores = (float *)malloc(seq_q * seq_k * sizeof(float));
+    if (!scores) return;
 
     for (int b = 0; b < batch; b++) {
         for (int h = 0; h < heads; h++) {
@@ -791,6 +792,11 @@ static void flash_attention_head_tiled(float *out,
     /* Per-query running statistics: max_score[seq_q], sum_exp[seq_q] */
     float *max_scores = (float *)malloc(seq_q * sizeof(float));
     float *sum_exps = (float *)malloc(seq_q * sizeof(float));
+    if (!max_scores || !sum_exps) {
+        free(max_scores);
+        free(sum_exps);
+        return;
+    }
 
     /* Initialize */
     for (int i = 0; i < seq_q; i++) {
@@ -904,6 +910,7 @@ void iris_flash_attention(float *out, const float *Q, const float *K, const floa
 
     /* Allocate tile scratch buffer */
     float *tile_scores = (float *)malloc(q_tile_size * k_tile_size * sizeof(float));
+    if (!tile_scores) return;
 
     /* Process each head */
     for (int h = 0; h < heads; h++) {
@@ -922,6 +929,10 @@ void iris_flash_attention(float *out, const float *Q, const float *K, const floa
             float *K_contig = (float *)malloc(seq_k * head_dim * sizeof(float));
             float *V_contig = (float *)malloc(seq_k * head_dim * sizeof(float));
             float *out_contig = (float *)malloc(seq_q * head_dim * sizeof(float));
+            if (!Q_contig || !K_contig || !V_contig || !out_contig) {
+                free(Q_contig); free(K_contig); free(V_contig); free(out_contig);
+                break;
+            }
 
             for (int i = 0; i < seq_q; i++) {
                 for (int d = 0; d < head_dim; d++) {
@@ -956,6 +967,10 @@ void iris_flash_attention(float *out, const float *Q, const float *K, const floa
             float *K_contig = (float *)malloc(seq_k * head_dim * sizeof(float));
             float *V_contig = (float *)malloc(seq_k * head_dim * sizeof(float));
             float *out_contig = (float *)malloc(seq_q * head_dim * sizeof(float));
+            if (!Q_contig || !K_contig || !V_contig || !out_contig) {
+                free(Q_contig); free(K_contig); free(V_contig); free(out_contig);
+                break;
+            }
 
             for (int i = 0; i < seq_q; i++) {
                 for (int d = 0; d < head_dim; d++) {

--- a/iris_qwen3_tokenizer.c
+++ b/iris_qwen3_tokenizer.c
@@ -753,6 +753,7 @@ static token_node_t *bpe_encode_word(qwen3_tokenizer_t *tok, const char *word) {
             int len1 = strlen(best_node->text);
             int len2 = strlen(best_node->next->text);
             char *merged = malloc(len1 + len2 + 1);
+            if (!merged) break;
             memcpy(merged, best_node->text, len1);
             memcpy(merged + len1, best_node->next->text, len2);
             merged[len1 + len2] = '\0';
@@ -876,12 +877,15 @@ static char **pretokenize(const char *text, int *num_chunks) {
         if (p > start) {
             int len = p - start;
             char *chunk = malloc(len + 1);
+            if (!chunk) break;
             memcpy(chunk, start, len);
             chunk[len] = '\0';
 
             if (count >= capacity) {
                 capacity *= 2;
-                chunks = realloc(chunks, capacity * sizeof(char *));
+                char **new_chunks = realloc(chunks, capacity * sizeof(char *));
+                if (!new_chunks) { free(chunk); break; }
+                chunks = new_chunks;
             }
             chunks[count++] = chunk;
         }
@@ -926,7 +930,16 @@ int *qwen3_tokenize(qwen3_tokenizer_t *tok, const char *text,
             if (id >= 0) {
                 if (total >= capacity) {
                     capacity *= 2;
-                    tokens = realloc(tokens, capacity * sizeof(int));
+                    int *new_tokens = realloc(tokens, capacity * sizeof(int));
+                    if (!new_tokens) {
+                        free_token_list(bpe_tokens);
+                        free(byte_text);
+                        for (int i = c + 1; i < num_chunks; i++) free(chunks[i]);
+                        free(chunks);
+                        *num_tokens = total;
+                        return tokens;
+                    }
+                    tokens = new_tokens;
                 }
                 tokens[total++] = id;
             }


### PR DESCRIPTION
## Summary

Unguarded `malloc`/`realloc` calls in three files can crash with a NULL
dereference or silently lose the original pointer (memory leak) when the
system runs low on RAM during inference. This PR adds the missing checks
and ensures each failure path either returns early with a clear error or
yields a gracefully degraded result.

## Changes

### `iris_kernels.c`

| Function | Allocation | Failure handling |
|---|---|---|
| `iris_attention` | `scores` | return early (output zeroed by caller) |
| `flash_attention_head_tiled` | `max_scores` + `sum_exps` | free both, return early |
| `iris_flash_attention` | `tile_scores` | return early |
| `iris_flash_attention` | `Q/K/V/out_contig` (×2 paths) | free all four, `break` head loop |

### `iris.c`

- `iris_generate_zimage_with_embeddings`: `latent` was passed directly
  to `iris_patchify()` before checking for NULL; now frees `denoised`
  and returns NULL with an error message on failure.
- `iris_generate_with_embeddings_and_noise`: `z` was `memcpy`'d before
  checking for NULL; now returns NULL with an error message on failure.

### `iris_qwen3_tokenizer.c`

- `bpe_encode_word`: `merged` was used without a NULL check; now breaks
  the merge loop so the partially-merged word is still returned.
- `pretokenize`: `chunk` malloc and `realloc(chunks, ...)` were both
  unchecked; the realloc used the lost-pointer anti-pattern
  (`chunks = realloc(chunks, ...)`). Now uses a temp pointer so the
  original array is preserved on failure.
- `qwen3_tokenize`: same lost-pointer realloc on `tokens`; now uses a
  temp pointer and, on failure, cleans up remaining chunks and returns
  the partial token list rather than leaking or crashing.

## Testing

Compiles cleanly with `-Wall -Wextra` on MPS, BLAS, and generic targets.
All non-OOM code paths are unchanged.